### PR TITLE
apmeken: roof support menu entry config

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -394,6 +394,26 @@ public interface TombsOfAmascutConfig extends Config
 		return 100;
 	}
 
+	@ConfigSection(
+		name = "Path of Apmeken",
+		description = "Helpers for the Path of Apmeken.",
+		position = 700
+	)
+	String SECTION_APMEKEN = "sectionApmeken";
+
+	@ConfigItem(
+		keyName = "apmekenRoofDeprioritizeEnable",
+		name = "De-prioritize Roof Menu Entry",
+		description = "<html>De-prioritizes the repair roof menu entry when they are already fixed." +
+			"<br/>This prevents misclicking and taking damage.</html>",
+		position = 701,
+		section = SECTION_APMEKEN
+	)
+	default boolean apmekenRoofDeprioritizeEnable()
+	{
+		return false;
+	}
+
 	@ConfigItem(
 		keyName = "updateNotifierLastVersion",
 		name = "",

--- a/src/main/java/com/duckblade/osrs/toa/features/apmeken/ApmekenHelper.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/apmeken/ApmekenHelper.java
@@ -1,0 +1,117 @@
+package com.duckblade.osrs.toa.features.apmeken;
+
+import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
+import com.duckblade.osrs.toa.util.RaidRoom;
+import com.duckblade.osrs.toa.util.RaidState;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.util.Text;
+
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class ApmekenHelper implements PluginLifecycleComponent
+{
+
+	private static final String MESSAGE_SENSE_ROOF_SUPPORTS = "you sense an issue with the roof supports.";
+	private static final String MESSAGE_SENSE_FUMES = "you sense some strange fumes coming from holes in the floor.";
+	private static final String MESSAGE_FIX_ROOF_SUPPORTS = "you repair the damaged roof support.";
+	private static final String MESSAGE_FIX_ROOF_SUPPORTS_SIGHT = "apmeken's sight guides you into repairing the roof supports.";
+	private static final String MESSAGE_FIX_FUMES = "you neutralise the fumes coming from the hole.";
+	private static final String MESSAGE_FIX_FUMES_SIGHT = "apmeken's sight guides you into neutralising some dangerous fumes.";
+	private static final String MESSAGE_FAIL_ROOF_SUPPORTS = "damaged roof supports cause some debris to fall on you!";
+	private static final String MESSAGE_FAIL_FUMES = "the fumes filling the room suddenly ignite!";
+	private static final String MESSAGE_DIED = "you have died";
+	private static final String MESSAGE_CHALLENGE_COMPLETE = "challenge complete";
+
+	private final EventBus eventBus;
+	private final TombsOfAmascutConfig config;
+
+	private ApmekenSense apmekenSense = ApmekenSense.NONE;
+
+	@Override
+	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
+	{
+		return raidState.getCurrentRoom() == RaidRoom.APMEKEN;
+	}
+
+	@Override
+	public void startUp()
+	{
+		eventBus.register(this);
+		reset();
+	}
+
+	@Override
+	public void shutDown()
+	{
+		eventBus.unregister(this);
+		reset();
+	}
+
+	private void reset()
+	{
+		apmekenSense = ApmekenSense.NONE;
+	}
+
+	@Subscribe
+	public void onChatMessage(final ChatMessage event)
+	{
+		if (event.getType() != ChatMessageType.GAMEMESSAGE) return;
+
+		final String message = Text.standardize(event.getMessage());
+
+		if (message.startsWith(MESSAGE_CHALLENGE_COMPLETE) || message.startsWith(MESSAGE_DIED))
+		{
+			apmekenSense = ApmekenSense.NONE;
+			return;
+		}
+
+		switch (message)
+		{
+			case MESSAGE_FIX_ROOF_SUPPORTS:
+			case MESSAGE_FIX_ROOF_SUPPORTS_SIGHT:
+			case MESSAGE_FIX_FUMES:
+			case MESSAGE_FIX_FUMES_SIGHT:
+			case MESSAGE_FAIL_ROOF_SUPPORTS:
+			case MESSAGE_FAIL_FUMES:
+				apmekenSense = ApmekenSense.NONE;
+				break;
+			case MESSAGE_SENSE_FUMES:
+				apmekenSense = ApmekenSense.VENTS;
+				break;
+			case MESSAGE_SENSE_ROOF_SUPPORTS:
+				apmekenSense = ApmekenSense.ROOF;
+				break;
+			default:
+				break;
+		}
+	}
+
+	@Subscribe
+	public void onMenuEntryAdded(final MenuEntryAdded event)
+	{
+		if (!config.apmekenRoofDeprioritizeEnable() || apmekenSense == ApmekenSense.ROOF) return;
+
+		final MenuEntry menuEntry = event.getMenuEntry();
+
+		if (!menuEntry.getOption().equals("Repair")) return;
+
+		menuEntry.setDeprioritized(true);
+	}
+
+	private enum ApmekenSense
+	{
+		NONE,
+		VENTS,
+		ROOF
+	}
+
+}

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -4,6 +4,7 @@ import com.duckblade.osrs.toa.TombsOfAmascutConfig;
 import com.duckblade.osrs.toa.features.InvocationScreenshot;
 import com.duckblade.osrs.toa.features.QuickProceedSwaps;
 import com.duckblade.osrs.toa.features.SarcophagusOpeningSoundPlayer;
+import com.duckblade.osrs.toa.features.apmeken.ApmekenHelper;
 import com.duckblade.osrs.toa.features.apmeken.ApmekenWaveInstaller;
 import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerOverlay;
 import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerTracker;
@@ -39,6 +40,7 @@ public class TombsOfAmascutModule extends AbstractModule
 		Multibinder<PluginLifecycleComponent> lifecycleComponents = Multibinder.newSetBinder(binder(), PluginLifecycleComponent.class);
 		lifecycleComponents.addBinding().to(AdditionPuzzleSolver.class);
 		lifecycleComponents.addBinding().to(ApmekenWaveInstaller.class);
+		lifecycleComponents.addBinding().to(ApmekenHelper.class);
 		lifecycleComponents.addBinding().to(BeamTimerOverlay.class);
 		lifecycleComponents.addBinding().to(BeamTimerTracker.class);
 		lifecycleComponents.addBinding().to(DepositPickaxeSwap.class);


### PR DESCRIPTION
This feature deprioritizes the repair roof support menu entry when the roofs are already fixed. It is common to misclick the roof supports and take damage e.g. when having a low camera angle and clicking baboons.

I think this feature is allowed given that it is technically a puzzle room and not a boss?