### PR TITLE
Fix FlatLaf Compatability

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/features/apmeken/ApmekenWaveInstaller.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/apmeken/ApmekenWaveInstaller.java
@@ -59,16 +59,12 @@ public class ApmekenWaveInstaller implements PluginLifecycleComponent
 		clientToolbar.addNavigation(navButton);
 		SwingUtilities.invokeLater(() ->
 		{
-			if (!navButton.isSelected())
-			{
-				navButton.getOnSelect().run();
-			}
+			clientToolbar.openPanel(navButton);
 		});
 	}
 
 	private void removePanel()
 	{
-		navButton.setSelected(false);
 		clientToolbar.removeNavigation(navButton);
 	}
 }

--- a/src/main/java/com/duckblade/osrs/toa/features/scabaras/panel/ScabarasPanelManager.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/scabaras/panel/ScabarasPanelManager.java
@@ -60,16 +60,12 @@ public class ScabarasPanelManager implements PluginLifecycleComponent
 		clientToolbar.addNavigation(navButton);
 		SwingUtilities.invokeLater(() ->
 		{
-			if (!navButton.isSelected())
-			{
-				navButton.getOnSelect().run();
-			}
+			clientToolbar.openPanel(navButton);
 		});
 	}
 
 	private void removePanel()
 	{
-		navButton.setSelected(false);
 		clientToolbar.removeNavigation(navButton);
 	}
 }

--- a/src/main/java/com/duckblade/osrs/toa/features/updatenotifier/UpdateNotifier.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/updatenotifier/UpdateNotifier.java
@@ -55,10 +55,7 @@ public class UpdateNotifier implements PluginLifecycleComponent
 
 			SwingUtilities.invokeLater(() ->
 			{
-				if (!navButton.isSelected())
-				{
-					navButton.getOnSelect().run();
-				}
+				clientToolbar.openPanel(navButton);
 			});
 		});
 	}


### PR DESCRIPTION
Fixes #72

This PR is a quick patch for the plugin to be compatible with the RuneLite FlatLaf changes (runelite/runelite#17284), that was made live recently, that broke the plugin.

Primarily, this involves using `clientToolbar.openPanel(navButton)` in place of the original `navButton.getOnSelect().run()` (w/ if) to open the panel, and removing `navButton.setSelected(false)`, as it doesn't exist anymore, and `.removeNavigation()` takes care of it.