### PR TITLE
tomb: detect cursed phalanx

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -588,14 +588,12 @@ public interface TombsOfAmascutConfig extends Config
 		return new Color(17, 88, 152);
 	}
 
-	String CURSED_PHALANX_DETECT = "cursedPhalanxDetect";
-
 	@ConfigItem(
 		name = "Detect Cursed Phalanx",
 		description = "Prevents opening chests if player is carrying a cursed phalanx" +
 			"<br>or Osmumten's fang (or).",
 		position = 609,
-		keyName = CURSED_PHALANX_DETECT,
+		keyName = "cursedPhalanxDetect",
 		section = SECTION_BURIAL_TOMB
 	)
 	default boolean cursedPhalanxDetect()

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -588,6 +588,21 @@ public interface TombsOfAmascutConfig extends Config
 		return new Color(17, 88, 152);
 	}
 
+	String CURSED_PHALANX_DETECT = "cursedPhalanxDetect";
+
+	@ConfigItem(
+		name = "Detect Cursed Phalanx",
+		description = "Prevents opening chests if player is carrying a cursed phalanx" +
+			"<br>or Osmumten's fang (or).",
+		position = 609,
+		keyName = CURSED_PHALANX_DETECT,
+		section = SECTION_BURIAL_TOMB
+	)
+	default boolean cursedPhalanxDetect()
+	{
+		return false;
+	}
+
 	@ConfigSection(
 		name = "Time Tracking",
 		description = "Time tracking and splits.",

--- a/src/main/java/com/duckblade/osrs/toa/features/tomb/CursedPhalanxDetector.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/tomb/CursedPhalanxDetector.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
@@ -20,6 +21,7 @@ import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 
 @Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 public class CursedPhalanxDetector implements PluginLifecycleComponent
 {
 	private static final Set<Integer> CURSED_PHALANX_ITEM_IDS = ImmutableSet.of(
@@ -27,12 +29,8 @@ public class CursedPhalanxDetector implements PluginLifecycleComponent
 		ItemID.OSMUMTENS_FANG_OR
 	);
 
-	@Inject
-	private EventBus eventBus;
-	@Inject
-	private Client client;
-	@Inject
-	private TombsOfAmascutConfig config;
+	private final EventBus eventBus;
+	private final Client client;
 
 	@Override
 	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
@@ -74,7 +72,6 @@ public class CursedPhalanxDetector implements PluginLifecycleComponent
 		{
 			event.consume();
 			client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Remove and/or drop cursed phalanx before doing that.", null);
-			return;
 		}
 	}
 }

--- a/src/main/java/com/duckblade/osrs/toa/features/tomb/CursedPhalanxDetector.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/tomb/CursedPhalanxDetector.java
@@ -1,0 +1,90 @@
+package com.duckblade.osrs.toa.features.tomb;
+
+import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
+import com.duckblade.osrs.toa.util.RaidRoom;
+import com.duckblade.osrs.toa.util.RaidState;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+
+@Singleton
+public class CursedPhalanxDetector implements PluginLifecycleComponent
+{
+	@Inject
+	private EventBus eventBus;
+	@Inject
+	private Client client;
+	@Inject
+	private TombsOfAmascutConfig config;
+
+	@Override
+	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
+	{
+		return raidState.getCurrentRoom() == RaidRoom.TOMB && config.cursedPhalanxDetect();
+	}
+
+	@Override
+	public void startUp()
+	{
+		eventBus.register(this);
+	}
+
+	@Override
+	public void shutDown()
+	{
+		eventBus.unregister(this);
+	}
+
+	@Subscribe
+	private void onMenuOptionClicked(final MenuOptionClicked event)
+	{
+		if (!config.cursedPhalanxDetect() || client.getVarbitValue(Varbits.TOA_RAID_LEVEL) < 500)
+		{
+			return;
+		}
+
+		final MenuEntry menuEntry = event.getMenuEntry();
+
+		if (!menuEntry.getOption().equals("Open"))
+		{
+			return;
+		}
+
+		ItemContainer itemContainer = client.getItemContainer(InventoryID.EQUIPMENT);
+
+		if (itemContainer != null)
+		{
+			final Item weapon = itemContainer.getItem(EquipmentInventorySlot.WEAPON.getSlotIdx());
+
+			if (weapon != null && weapon.getId() == ItemID.OSMUMTENS_FANG_OR)
+			{
+				event.consume();
+				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Remove and/or drop cursed phalanx before doing that.", null);
+				return;
+			}
+		}
+
+		itemContainer = client.getItemContainer(InventoryID.INVENTORY);
+
+		if (itemContainer != null)
+		{
+			if (itemContainer.contains(ItemID.OSMUMTENS_FANG_OR) || itemContainer.contains(ItemID.CURSED_PHALANX))
+			{
+				event.consume();
+				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Remove and/or drop cursed phalanx before doing that.", null);
+			}
+		}
+	}
+}

--- a/src/main/java/com/duckblade/osrs/toa/features/tomb/CursedPhalanxDetector.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/tomb/CursedPhalanxDetector.java
@@ -12,7 +12,6 @@ import javax.inject.Singleton;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
-import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.Varbits;
@@ -68,21 +67,14 @@ public class CursedPhalanxDetector implements PluginLifecycleComponent
 			return;
 		}
 
-		final ItemContainer eq = client.getItemContainer(InventoryID.EQUIPMENT);
-		final ItemContainer inv = client.getItemContainer(InventoryID.INVENTORY);
-
-		if (eq == null || inv == null)
-		{
-			return;
-		}
-
-		final boolean wearingPhalanx = InventoryUtil.containsAny(eq, CURSED_PHALANX_ITEM_IDS);
-		final boolean carryingPhalanx = InventoryUtil.containsAny(inv, CURSED_PHALANX_ITEM_IDS);
+		boolean wearingPhalanx = InventoryUtil.containsAny(client.getItemContainer(InventoryID.EQUIPMENT), CURSED_PHALANX_ITEM_IDS);
+		boolean carryingPhalanx = InventoryUtil.containsAny(client.getItemContainer(InventoryID.INVENTORY), CURSED_PHALANX_ITEM_IDS);
 
 		if (wearingPhalanx || carryingPhalanx)
 		{
 			event.consume();
 			client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Remove and/or drop cursed phalanx before doing that.", null);
+			return;
 		}
 	}
 }

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -28,6 +28,7 @@ import com.duckblade.osrs.toa.features.scabaras.panel.ScabarasPanelManager;
 import com.duckblade.osrs.toa.features.timetracking.SplitsOverlay;
 import com.duckblade.osrs.toa.features.timetracking.SplitsTracker;
 import com.duckblade.osrs.toa.features.timetracking.TargetTimeManager;
+import com.duckblade.osrs.toa.features.tomb.CursedPhalanxDetector;
 import com.duckblade.osrs.toa.features.tomb.SarcophagusRecolorer;
 import com.duckblade.osrs.toa.features.tomb.SarcophagusOpeningSoundPlayer;
 import com.duckblade.osrs.toa.features.updatenotifier.UpdateNotifier;
@@ -78,6 +79,7 @@ public class TombsOfAmascutModule extends AbstractModule
 		lifecycleComponents.addBinding().to(TargetTimeManager.class);
 		lifecycleComponents.addBinding().to(UpdateNotifier.class);
 		lifecycleComponents.addBinding().to(SarcophagusRecolorer.class);
+		lifecycleComponents.addBinding().to(CursedPhalanxDetector.class);
 	}
 
 	@Provides

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -52,6 +52,7 @@ public class TombsOfAmascutModule extends AbstractModule
 		lifecycleComponents.addBinding().to(ApmekenWaveInstaller.class);
 		lifecycleComponents.addBinding().to(BeamTimerOverlay.class);
 		lifecycleComponents.addBinding().to(BeamTimerTracker.class);
+		lifecycleComponents.addBinding().to(CursedPhalanxDetector.class);
 		lifecycleComponents.addBinding().to(DepositPickaxeOverlay.class);
 		lifecycleComponents.addBinding().to(DepositPickaxePreventEntry.class);
 		lifecycleComponents.addBinding().to(DepositPickaxeSwap.class);
@@ -70,6 +71,7 @@ public class TombsOfAmascutModule extends AbstractModule
 		lifecycleComponents.addBinding().to(QuickProceedSwaps.class);
 		lifecycleComponents.addBinding().to(RaidStateTracker.class);
 		lifecycleComponents.addBinding().to(SarcophagusOpeningSoundPlayer.class);
+		lifecycleComponents.addBinding().to(SarcophagusRecolorer.class);
 		lifecycleComponents.addBinding().to(ScabarasOverlayManager.class);
 		lifecycleComponents.addBinding().to(ScabarasPanelManager.class);
 		lifecycleComponents.addBinding().to(SequencePuzzleSolver.class);
@@ -78,8 +80,6 @@ public class TombsOfAmascutModule extends AbstractModule
 		lifecycleComponents.addBinding().to(SplitsTracker.class);
 		lifecycleComponents.addBinding().to(TargetTimeManager.class);
 		lifecycleComponents.addBinding().to(UpdateNotifier.class);
-		lifecycleComponents.addBinding().to(SarcophagusRecolorer.class);
-		lifecycleComponents.addBinding().to(CursedPhalanxDetector.class);
 	}
 
 	@Provides

--- a/src/main/java/com/duckblade/osrs/toa/util/InventoryUtil.java
+++ b/src/main/java/com/duckblade/osrs/toa/util/InventoryUtil.java
@@ -12,16 +12,16 @@ public class InventoryUtil
 	public static boolean containsAny(Client client, Set<Integer> ids)
 	{
 		ItemContainer inv = client.getItemContainer(InventoryID.INVENTORY);
-		if (inv == null)
-		{
-			return false;
-		}
-
 		return containsAny(inv, ids);
 	}
 
 	public static boolean containsAny(ItemContainer inv, Set<Integer> ids)
 	{
+		if (inv == null)
+		{
+			return false;
+		}
+
 		for (Item item : inv.getItems())
 		{
 			if (ids.contains(item.getId()))


### PR DESCRIPTION
This config prevents opening the chest while carrying a cursed phalanx when the raid level is >= 500.
If you drop it on the ground and open the chest you receive another one, which can be high alched for 60k gp.
Most players put a reminder to remove their fang kit in the form of a tile marker with a label, so this is a better alternative to that.