### PR TITLE
feat: purple dry streak tracker

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -46,6 +46,7 @@ public interface TombsOfAmascutConfig extends Config
 	}
 
 	String KEY_HP_ORB_MODE = "hpOrbsMode";
+
 	@ConfigItem(
 		keyName = KEY_HP_ORB_MODE,
 		name = "HP Orbs",
@@ -612,6 +613,18 @@ public interface TombsOfAmascutConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		name = "Track Purple Dry Count",
+		description = "Show purple dry streak count in chat upon raid completion.",
+		position = 610,
+		keyName = "trackPurpleDryCount",
+		section = SECTION_BURIAL_TOMB
+	)
+	default boolean trackPurpleDryCount()
+	{
+		return false;
+	}
+
 	@ConfigSection(
 		name = "Time Tracking",
 		description = "Time tracking and splits.",
@@ -675,4 +688,22 @@ public interface TombsOfAmascutConfig extends Config
 	)
 	void updateNotifierLastVersion(int newVersion);
 
+	@ConfigItem(
+		keyName = "purpleDryStreakCount",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	default int getPurpleDryStreakCount()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		keyName = "purpleDryStreakCount",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	void setPurpleDryStreakCount(int count);
 }

--- a/src/main/java/com/duckblade/osrs/toa/features/tomb/DryStreakTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/tomb/DryStreakTracker.java
@@ -1,0 +1,85 @@
+package com.duckblade.osrs.toa.features.tomb;
+
+import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
+import com.duckblade.osrs.toa.util.RaidRoom;
+import com.duckblade.osrs.toa.util.RaidState;
+import com.duckblade.osrs.toa.util.RaidStateTracker;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.InterfaceID;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class DryStreakTracker implements PluginLifecycleComponent
+{
+	private static final int VARBIT_ID_SARCOPHAGUS = 14373;
+
+	private final EventBus eventBus;
+	private final Client client;
+	private final ClientThread clientThread;
+	private final TombsOfAmascutConfig config;
+	private final ChatMessageManager chatMessageManager;
+	private final RaidStateTracker raidStateTracker;
+
+	private boolean chestOpened;
+
+	@Override
+	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
+	{
+		return config.trackPurpleDryCount() && (raidState.getCurrentRoom() == RaidRoom.TOMB || raidState.isInLobby());
+	}
+
+	@Override
+	public void startUp()
+	{
+		eventBus.register(this);
+
+		// TODO: prevent arbitrarily increasing counter by toggling config option
+		if (raidStateTracker.getCurrentState().getCurrentRoom() == RaidRoom.TOMB)
+		{
+			clientThread.invokeLater(() ->
+			{
+				final boolean purple = client.getVarbitValue(VARBIT_ID_SARCOPHAGUS) % 2 != 0;
+				config.setPurpleDryStreakCount(purple ? 0 : config.getPurpleDryStreakCount() + 1);
+				chestOpened = false;
+			});
+		}
+	}
+
+	@Override
+	public void shutDown()
+	{
+		eventBus.unregister(this);
+	}
+
+	@Subscribe
+	public void onWidgetLoaded(final WidgetLoaded widgetLoaded)
+	{
+		if (chestOpened)
+		{
+			return;
+		}
+
+		if (widgetLoaded.getGroupId() == InterfaceID.TOA_REWARD)
+		{
+			chestOpened = true;
+
+			final String msg = String.format("<col=800080>Purple</col> Dry Streak: <col=ff0000>%d</col>", config.getPurpleDryStreakCount());
+
+			chatMessageManager.queue(QueuedMessage.builder()
+				.type(ChatMessageType.GAMEMESSAGE)
+				.runeLiteFormattedMessage(msg)
+				.build());
+		}
+	}
+}

--- a/src/main/java/com/duckblade/osrs/toa/features/tomb/DryStreakTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/tomb/DryStreakTracker.java
@@ -32,6 +32,8 @@ public class DryStreakTracker implements PluginLifecycleComponent
 	private final RaidStateTracker raidStateTracker;
 
 	private boolean chestOpened;
+	private boolean purple;
+	private int previousCount;
 
 	@Override
 	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
@@ -49,9 +51,10 @@ public class DryStreakTracker implements PluginLifecycleComponent
 		{
 			clientThread.invokeLater(() ->
 			{
-				final boolean purple = client.getVarbitValue(VARBIT_ID_SARCOPHAGUS) % 2 != 0;
-				config.setPurpleDryStreakCount(purple ? 0 : config.getPurpleDryStreakCount() + 1);
 				chestOpened = false;
+				purple = client.getVarbitValue(VARBIT_ID_SARCOPHAGUS) % 2 != 0;
+				previousCount = config.getPurpleDryStreakCount();
+				config.setPurpleDryStreakCount(purple ? 0 : previousCount + 1);
 			});
 		}
 	}
@@ -74,7 +77,16 @@ public class DryStreakTracker implements PluginLifecycleComponent
 		{
 			chestOpened = true;
 
-			final String msg = String.format("<col=800080>Purple</col> Dry Streak: <col=ff0000>%d</col>", config.getPurpleDryStreakCount());
+			final String msg;
+
+			if (purple)
+			{
+				msg = String.format("<col=800080>Purple</col> Dry Streak Ended: <col=ff0000>%d</col>", previousCount);
+			}
+			else
+			{
+				msg = String.format("<col=800080>Purple</col> Dry Streak: <col=ff0000>%d</col>", config.getPurpleDryStreakCount());
+			}
 
 			chatMessageManager.queue(QueuedMessage.builder()
 				.type(ChatMessageType.GAMEMESSAGE)

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -30,6 +30,7 @@ import com.duckblade.osrs.toa.features.timetracking.SplitsOverlay;
 import com.duckblade.osrs.toa.features.timetracking.SplitsTracker;
 import com.duckblade.osrs.toa.features.timetracking.TargetTimeManager;
 import com.duckblade.osrs.toa.features.tomb.CursedPhalanxDetector;
+import com.duckblade.osrs.toa.features.tomb.DryStreakTracker;
 import com.duckblade.osrs.toa.features.tomb.SarcophagusRecolorer;
 import com.duckblade.osrs.toa.features.tomb.SarcophagusOpeningSoundPlayer;
 import com.duckblade.osrs.toa.features.updatenotifier.UpdateNotifier;
@@ -57,6 +58,7 @@ public class TombsOfAmascutModule extends AbstractModule
 		lifecycleComponents.addBinding().to(DepositPickaxeOverlay.class);
 		lifecycleComponents.addBinding().to(DepositPickaxePreventEntry.class);
 		lifecycleComponents.addBinding().to(DepositPickaxeSwap.class);
+		lifecycleComponents.addBinding().to(DryStreakTracker.class);
 		lifecycleComponents.addBinding().to(FadeDisabler.class);
 		lifecycleComponents.addBinding().to(HetSolver.class);
 		lifecycleComponents.addBinding().to(HetSolverOverlay.class);


### PR DESCRIPTION
Tracks # of runs since last purple and prints the count in the chat.