### PR TITLE
feat: disable fade transition

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -79,6 +79,17 @@ public interface TombsOfAmascutConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+		keyName = "hideFadeTransition",
+		name = "Hide Fade Transition",
+		description = "Hides the fade transition between loading zones.",
+		position = 9
+	)
+	default boolean hideFadeTransition()
+	{
+		return false;
+	}
+
 	@ConfigSection(
 		name = "Invocation Presets",
 		description = "Save presets of invocations to quickly restore your invocations between runs of different types.",

--- a/src/main/java/com/duckblade/osrs/toa/features/FadeDisabler.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/FadeDisabler.java
@@ -1,0 +1,46 @@
+package com.duckblade.osrs.toa.features;
+
+import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
+import com.duckblade.osrs.toa.util.RaidState;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.events.ScriptPreFired;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+
+@Singleton
+public class FadeDisabler implements PluginLifecycleComponent
+{
+	@Inject
+	private EventBus eventBus;
+
+	@Override
+	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
+	{
+		return config.hideFadeTransition() && (raidState.isInLobby() || raidState.isInRaid());
+	}
+
+	@Override
+	public void startUp()
+	{
+		eventBus.register(this);
+	}
+
+	@Override
+	public void shutDown()
+	{
+		eventBus.unregister(this);
+	}
+
+	@Subscribe
+	private void onScriptPreFired(final ScriptPreFired event)
+	{
+		// https://github.com/RuneStar/cs2-scripts/blob/master/scripts/%5Bclientscript%2Cfade_overlay%5D.cs2
+		if (event.getScriptId() == 948)
+		{
+			event.getScriptEvent().getArguments()[4] = 255; // transparency (default=0)
+			event.getScriptEvent().getArguments()[5] = 0; // duration? (default=50)
+		}
+	}
+}

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -1,6 +1,7 @@
 package com.duckblade.osrs.toa.module;
 
 import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import com.duckblade.osrs.toa.features.FadeDisabler;
 import com.duckblade.osrs.toa.features.InvocationScreenshot;
 import com.duckblade.osrs.toa.features.LeftClickBankAll;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeOverlay;
@@ -54,6 +55,7 @@ public class TombsOfAmascutModule extends AbstractModule
 		lifecycleComponents.addBinding().to(DepositPickaxeOverlay.class);
 		lifecycleComponents.addBinding().to(DepositPickaxePreventEntry.class);
 		lifecycleComponents.addBinding().to(DepositPickaxeSwap.class);
+		lifecycleComponents.addBinding().to(FadeDisabler.class);
 		lifecycleComponents.addBinding().to(HetSolver.class);
 		lifecycleComponents.addBinding().to(HetSolverOverlay.class);
 		lifecycleComponents.addBinding().to(HpOrbManager.class);


### PR DESCRIPTION
This hides the fade transition between rooms by making the black overlay 100% transparent.
It can possibly help save ticks by being able to see where to click before the player is able to move again.

To demonstrate, this gif shows the fade set to 50% transparency,

![java_rMzsIiOsMy](https://github.com/LlemonDuck/tombs-of-amascut/assets/38548565/a2290e04-920f-4051-9967-fd24023bded8)
