### PR TITLE
feat: akkhas shadows hp overlay

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -7,6 +7,7 @@ import com.duckblade.osrs.toa.features.scabaras.SkipObeliskOverlay;
 import com.duckblade.osrs.toa.features.scabaras.overlay.MatchingTileDisplayMode;
 import com.duckblade.osrs.toa.features.timetracking.SplitsMode;
 import com.duckblade.osrs.toa.features.updatenotifier.UpdateNotifier;
+import com.duckblade.osrs.toa.util.FontStyle;
 import com.duckblade.osrs.toa.util.HighlightMode;
 import java.awt.Color;
 import net.runelite.client.config.Alpha;
@@ -15,6 +16,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 
 @ConfigGroup(TombsOfAmascutConfig.CONFIG_GROUP)
 public interface TombsOfAmascutConfig extends Config
@@ -668,6 +670,52 @@ public interface TombsOfAmascutConfig extends Config
 	default SplitsMode splitsOverlay()
 	{
 		return SplitsMode.OFF;
+	}
+
+	@ConfigSection(
+		name = "Akkha",
+		description = "Configuration for Akkha boss room.",
+		closedByDefault = true,
+		position = 800
+	)
+	String SECTION_AKKHA = "sectionAkkha";
+
+	@ConfigItem(
+		name = "Shadows Hp Overlay",
+		description = "Overlay Akkha's Shadows Hp.",
+		position = 801,
+		keyName = "akkhaShadowHpOverlay",
+		section = SECTION_AKKHA
+	)
+	default boolean akkhaShadowHpOverlay()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		name = "Font Style",
+		description = "Font style of text overlay.",
+		position = 802,
+		keyName = "akkhaFontStyle",
+		section = SECTION_AKKHA
+	)
+	default FontStyle akkhaFontStyle()
+	{
+		return FontStyle.PLAIN;
+	}
+
+	@ConfigItem(
+		name = "Font Size",
+		description = "Font size of text overlay.",
+		position = 803,
+		keyName = "akkhaFontSize",
+		section = SECTION_AKKHA
+	)
+	@Units(Units.PIXELS)
+	@Range(min = 12)
+	default int akkhaFontSize()
+	{
+		return 12;
 	}
 
 	@ConfigSection(

--- a/src/main/java/com/duckblade/osrs/toa/features/PathLevelTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/PathLevelTracker.java
@@ -1,0 +1,133 @@
+package com.duckblade.osrs.toa.features;
+
+import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
+import com.duckblade.osrs.toa.util.RaidRoom;
+import com.duckblade.osrs.toa.util.RaidState;
+import com.duckblade.osrs.toa.util.RaidStateTracker;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class PathLevelTracker implements PluginLifecycleComponent
+{
+	private static final int CHILD_ID_DEFAULT = 45;
+	private static final int CHILD_ID_KEPHRI = 49;
+	private static final int CHILD_ID_AKKHA = 51;
+	private static final int CHILD_ID_BABA = 53;
+	private static final int CHILD_ID_ZEBAK = 55;
+
+	private final EventBus eventBus;
+	private final Client client;
+	private final RaidStateTracker raidStateTracker;
+
+	@Getter
+	private int kephriPathLevel;
+	@Getter
+	private int akkhaPathLevel;
+	@Getter
+	private int babaPathLevel;
+	@Getter
+	private int zebakPathLevel;
+
+	@Override
+	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
+	{
+		return raidState.isInRaid();
+	}
+
+	@Override
+	public void startUp()
+	{
+		eventBus.register(this);
+		readPathLevels();
+	}
+
+	@Override
+	public void shutDown()
+	{
+		eventBus.unregister(this);
+	}
+
+	@Subscribe
+	public void onWidgetLoaded(final WidgetLoaded event)
+	{
+		final int groupId = event.getGroupId();
+
+		if (groupId == InterfaceID.TOA_RAID)
+		{
+			readPathLevels();
+		}
+	}
+
+	private void readPathLevels()
+	{
+		final RaidRoom raidRoom = raidStateTracker.getCurrentState().getCurrentRoom();
+
+		Widget widget;
+
+		if (raidRoom == RaidRoom.NEXUS)
+		{
+			if ((widget = client.getWidget(InterfaceID.TOA_RAID, CHILD_ID_KEPHRI)) != null)
+			{
+				kephriPathLevel = Integer.parseInt(widget.getText());
+			}
+
+			if ((widget = client.getWidget(InterfaceID.TOA_RAID, CHILD_ID_AKKHA)) != null)
+			{
+				akkhaPathLevel = Integer.parseInt(widget.getText());
+			}
+
+			if ((widget = client.getWidget(InterfaceID.TOA_RAID, CHILD_ID_BABA)) != null)
+			{
+				babaPathLevel = Integer.parseInt(widget.getText());
+			}
+
+			if ((widget = client.getWidget(InterfaceID.TOA_RAID, CHILD_ID_ZEBAK)) != null)
+			{
+				zebakPathLevel = Integer.parseInt(widget.getText());
+			}
+		}
+		else
+		{
+			if ((widget = client.getWidget(InterfaceID.TOA_RAID, CHILD_ID_DEFAULT)) == null)
+			{
+				return;
+			}
+
+			final int pathLevel = Integer.parseInt(widget.getText());
+
+			switch (raidRoom)
+			{
+				case CRONDIS:
+				case ZEBAK:
+					zebakPathLevel = pathLevel;
+					break;
+				case SCABARAS:
+				case KEPHRI:
+					kephriPathLevel = pathLevel;
+					break;
+				case APMEKEN:
+				case BABA:
+					babaPathLevel = pathLevel;
+					break;
+				case HET:
+				case AKKHA:
+					akkhaPathLevel = pathLevel;
+					break;
+				default:
+					break;
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/duckblade/osrs/toa/features/boss/akkha/AkkhaShadowHealth.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/boss/akkha/AkkhaShadowHealth.java
@@ -1,0 +1,149 @@
+package com.duckblade.osrs.toa.features.boss.akkha;
+
+import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import com.duckblade.osrs.toa.features.PathLevelTracker;
+import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
+import com.duckblade.osrs.toa.util.NpcUtil;
+import com.duckblade.osrs.toa.util.RaidRoom;
+import com.duckblade.osrs.toa.util.RaidState;
+import com.duckblade.osrs.toa.util.RaidStateTracker;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.NpcID;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.NpcSpawned;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class AkkhaShadowHealth implements PluginLifecycleComponent
+{
+	private static final int BASE_HP_AKKHAS_SHADOW = 70;
+
+	private final EventBus eventBus;
+	private final Client client;
+	private final PathLevelTracker pathLevelTracker;
+	private final RaidStateTracker raidStateTracker;
+
+	@Getter(AccessLevel.PACKAGE)
+	private final Map<NPC, Integer> akkhasShadows = new HashMap<>();
+
+	@Getter(AccessLevel.PACKAGE)
+	private int akkhasShadowMaxHp;
+
+	@Override
+	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
+	{
+		return raidState.getCurrentRoom() == RaidRoom.AKKHA;
+	}
+
+	@Override
+	public void startUp()
+	{
+		eventBus.register(this);
+		updateAkkhasShadowMaxHp();
+	}
+
+	@Override
+	public void shutDown()
+	{
+		eventBus.unregister(this);
+		reset();
+	}
+
+	private void reset()
+	{
+		akkhasShadows.clear();
+		akkhasShadowMaxHp = 0;
+	}
+
+	@Subscribe
+	private void onGameTick(final GameTick event)
+	{
+		akkhasShadows.entrySet().forEach(e ->
+		{
+			NPC npc = e.getKey();
+			if (npc.getModel() != null && npc.getModel().getOverrideAmount() != 0)
+			{
+				// inactive state uses model overrides to "white-out" the npc
+				e.setValue(-1);
+				return;
+			}
+
+			final int trueHp = NpcUtil.calculateActorHp(e.getKey(), akkhasShadowMaxHp);
+			if (trueHp != -1)
+			{
+				e.setValue(trueHp);
+			}
+		});
+	}
+
+	@Subscribe
+	private void onNpcSpawned(final NpcSpawned event)
+	{
+		final NPC npc = event.getNpc();
+
+		if (npc.getId() == NpcID.AKKHAS_SHADOW)
+		{
+			akkhasShadows.put(npc, akkhasShadowMaxHp);
+		}
+	}
+
+	@Subscribe
+	private void onNpcDespawned(final NpcDespawned event)
+	{
+		final NPC npc = event.getNpc();
+
+		if (npc.getId() == NpcID.AKKHAS_SHADOW)
+		{
+			akkhasShadows.remove(npc);
+		}
+	}
+
+	private void updateAkkhasShadowMaxHp()
+	{
+		// Calculate max hp manually as NPCManager does not have this information
+		int hp = BASE_HP_AKKHAS_SHADOW;
+
+		final int raidLevelFactor = 4 * client.getVarbitValue(Varbits.TOA_RAID_LEVEL) / 10;
+		hp += hp * raidLevelFactor / 100;
+
+		final int pathLevel = pathLevelTracker.getAkkhaPathLevel();
+		if (pathLevel > 0)
+		{
+			// first level is 8%, others are 5%
+			final int pathLevelFactor = 3 + 5 * pathLevel;
+			hp += hp * pathLevelFactor / 100;
+		}
+
+		final int partySize = raidStateTracker.getPlayerCount();
+		if (partySize >= 2)
+		{
+			int partyFactor = 9 * (partySize == 3 ? 2 : 1);
+			if (partySize >= 4)
+			{
+				partyFactor += 6 * (partySize - 3);
+			}
+			hp += hp * partyFactor / 10;
+		}
+
+		// rounding
+		if (hp > 100)
+		{
+			final int roundTo = hp > 300 ? 10 : 5;
+			hp = ((hp + (roundTo / 2)) / roundTo) * roundTo;
+		}
+
+		akkhasShadowMaxHp = hp;
+	}
+}

--- a/src/main/java/com/duckblade/osrs/toa/features/boss/akkha/AkkhaShadowHealthOverlay.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/boss/akkha/AkkhaShadowHealthOverlay.java
@@ -1,0 +1,80 @@
+package com.duckblade.osrs.toa.features.boss.akkha;
+
+import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
+import com.duckblade.osrs.toa.util.OverlayUtil;
+import com.duckblade.osrs.toa.util.RaidState;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.Point;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+@Singleton
+public class AkkhaShadowHealthOverlay extends Overlay implements PluginLifecycleComponent
+{
+	private final TombsOfAmascutConfig config;
+	private final OverlayManager overlayManager;
+	private final AkkhaShadowHealth akkhaShadowHealth;
+
+	@Inject
+	protected AkkhaShadowHealthOverlay(
+		final TombsOfAmascutConfig config,
+		final OverlayManager overlayManager,
+		final AkkhaShadowHealth akkhaShadowHealth
+	)
+	{
+		this.config = config;
+		this.overlayManager = overlayManager;
+		this.akkhaShadowHealth = akkhaShadowHealth;
+
+		setPriority(Overlay.PRIORITY_HIGH);
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	@Override
+	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
+	{
+		return akkhaShadowHealth.isEnabled(config, raidState) && config.akkhaShadowHpOverlay();
+	}
+
+	@Override
+	public void startUp()
+	{
+		overlayManager.add(this);
+	}
+
+	@Override
+	public void shutDown()
+	{
+		overlayManager.remove(this);
+	}
+
+	@Override
+	public Dimension render(final Graphics2D graphics2D)
+	{
+		akkhaShadowHealth.getAkkhasShadows().forEach((npc, hp) ->
+		{
+			if (hp > 0)
+			{
+				final String text = Integer.toString(hp);
+
+				final Point point = npc.getCanvasTextLocation(graphics2D, text, 0);
+
+				if (point != null)
+				{
+					OverlayUtil.renderTextLocation(graphics2D, point, text, Color.WHITE, config.akkhaFontSize(),
+						config.akkhaFontStyle().getFont(), true);
+				}
+			}
+		});
+
+		return null;
+	}
+}

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -4,6 +4,8 @@ import com.duckblade.osrs.toa.TombsOfAmascutConfig;
 import com.duckblade.osrs.toa.features.FadeDisabler;
 import com.duckblade.osrs.toa.features.InvocationScreenshot;
 import com.duckblade.osrs.toa.features.LeftClickBankAll;
+import com.duckblade.osrs.toa.features.boss.akkha.AkkhaShadowHealth;
+import com.duckblade.osrs.toa.features.boss.akkha.AkkhaShadowHealthOverlay;
 import com.duckblade.osrs.toa.features.apmeken.ApmekenBaboonIndicator;
 import com.duckblade.osrs.toa.features.apmeken.ApmekenBaboonIndicatorOverlay;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeOverlay;
@@ -17,6 +19,7 @@ import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerOverlay;
 import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerTracker;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeSwap;
 import com.duckblade.osrs.toa.features.invocationpresets.InvocationPresetsManager;
+import com.duckblade.osrs.toa.features.PathLevelTracker;
 import com.duckblade.osrs.toa.features.pointstracker.PartyPointsTracker;
 import com.duckblade.osrs.toa.features.pointstracker.PointsOverlay;
 import com.duckblade.osrs.toa.features.pointstracker.PointsTracker;
@@ -53,6 +56,8 @@ public class TombsOfAmascutModule extends AbstractModule
 	{
 		Multibinder<PluginLifecycleComponent> lifecycleComponents = Multibinder.newSetBinder(binder(), PluginLifecycleComponent.class);
 		lifecycleComponents.addBinding().to(AdditionPuzzleSolver.class);
+		lifecycleComponents.addBinding().to(AkkhaShadowHealth.class);
+		lifecycleComponents.addBinding().to(AkkhaShadowHealthOverlay.class);
 		lifecycleComponents.addBinding().to(ApmekenBaboonIndicator.class);
 		lifecycleComponents.addBinding().to(ApmekenBaboonIndicatorOverlay.class);
 		lifecycleComponents.addBinding().to(ApmekenWaveInstaller.class);
@@ -74,6 +79,7 @@ public class TombsOfAmascutModule extends AbstractModule
 		lifecycleComponents.addBinding().to(MatchingPuzzleSolver.class);
 		lifecycleComponents.addBinding().to(ObeliskPuzzleSolver.class);
 		lifecycleComponents.addBinding().to(PartyPointsTracker.class);
+		lifecycleComponents.addBinding().to(PathLevelTracker.class);
 		lifecycleComponents.addBinding().to(PointsOverlay.class);
 		lifecycleComponents.addBinding().to(PointsTracker.class);
 		lifecycleComponents.addBinding().to(QuickProceedSwaps.class);

--- a/src/main/java/com/duckblade/osrs/toa/util/FontStyle.java
+++ b/src/main/java/com/duckblade/osrs/toa/util/FontStyle.java
@@ -1,0 +1,24 @@
+package com.duckblade.osrs.toa.util;
+
+import java.awt.Font;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public
+enum FontStyle
+{
+	PLAIN("Plain", Font.PLAIN),
+	BOLD("Bold", Font.BOLD),
+	ITALIC("Italic", Font.ITALIC);
+
+	private final String name;
+	private final int font;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/src/main/java/com/duckblade/osrs/toa/util/NpcUtil.java
+++ b/src/main/java/com/duckblade/osrs/toa/util/NpcUtil.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016-2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.duckblade.osrs.toa.util;
+
+import net.runelite.api.Actor;
+
+public final class NpcUtil
+{
+	private NpcUtil()
+	{
+	}
+
+	/**
+	 * Calculates Actor's current hitpoints
+	 * <p>
+	 * Adapted from RuneLite OpponentInfo Plugin
+	 *
+	 * @param actor the actor
+	 * @param maxHp the actor's max hp
+	 * @return the actor's current hp, else -1
+	 */
+	public static int calculateActorHp(final Actor actor, final int maxHp)
+	{
+		final int scale = actor.getHealthScale();
+		final int ratio = actor.getHealthRatio();
+
+		if (scale <= 0 || ratio < 0)
+		{
+			return -1;
+		}
+
+		int health = 0;
+
+		if (ratio > 0)
+		{
+			int minHealth = 1;
+			int maxHealth;
+
+			if (scale > 1)
+			{
+				if (ratio > 1)
+				{
+					minHealth = (maxHp * (ratio - 1) + scale - 2) / (scale - 1);
+				}
+
+				maxHealth = (maxHp * ratio - 1) / (scale - 1);
+
+				if (maxHealth > maxHp)
+				{
+					maxHealth = maxHp;
+				}
+			}
+			else
+			{
+				maxHealth = maxHp;
+			}
+
+			health = (minHealth + maxHealth + 1) / 2;
+		}
+
+		return health;
+	}
+}

--- a/src/main/java/com/duckblade/osrs/toa/util/OverlayUtil.java
+++ b/src/main/java/com/duckblade/osrs/toa/util/OverlayUtil.java
@@ -2,15 +2,16 @@ package com.duckblade.osrs.toa.util;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Graphics2D;
+import lombok.experimental.UtilityClass;
+import net.runelite.api.Point;
 import java.awt.Shape;
 import java.awt.Stroke;
 
+@UtilityClass
 public final class OverlayUtil
 {
-	private OverlayUtil()
-	{
-	}
 
 	public static void drawOutlineAndFill(final Graphics2D graphics2D, final Color outlineColor, final Color fillColor, final float strokeWidth, final Shape shape)
 	{
@@ -27,4 +28,30 @@ public final class OverlayUtil
 		graphics2D.setColor(originalColor);
 		graphics2D.setStroke(originalStroke);
 	}
+
+	public static void renderTextLocation(final Graphics2D graphics2D, final Point point, final String text, final Color color, final int size, final int style, final boolean shadow)
+	{
+		if (text == null || text.isEmpty())
+		{
+			return;
+		}
+
+		final Color origColor = graphics2D.getColor();
+		final Font origFont = graphics2D.getFont();
+
+		graphics2D.setFont(new Font(null, style, size));
+
+		if (shadow)
+		{
+			graphics2D.setColor(Color.BLACK);
+			graphics2D.drawString(text, point.getX() + 1, point.getY() + 1);
+		}
+
+		graphics2D.setColor(color);
+		graphics2D.drawString(text, point.getX(), point.getY());
+
+		graphics2D.setFont(origFont);
+		graphics2D.setColor(origColor);
+	}
+
 }

--- a/src/test/java/launcher/debugplugins/AkkhaShadowOverridesOverlay.java
+++ b/src/test/java/launcher/debugplugins/AkkhaShadowOverridesOverlay.java
@@ -1,0 +1,104 @@
+package launcher.debugplugins;
+
+import com.duckblade.osrs.toa.util.FontStyle;
+import com.duckblade.osrs.toa.util.OverlayUtil;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.inject.Singleton;
+import net.runelite.api.Model;
+import net.runelite.api.NPC;
+import net.runelite.api.NpcID;
+import net.runelite.api.NpcOverrides;
+import net.runelite.api.Point;
+import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.NpcSpawned;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+@Singleton
+public class AkkhaShadowOverridesOverlay extends Overlay
+{
+
+	private final Set<NPC> shadows = new TreeSet<>(Comparator.comparing(NPC::getIndex));
+
+	public AkkhaShadowOverridesOverlay()
+	{
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	@Subscribe
+	public void onNpcSpawned(NpcSpawned e)
+	{
+		if (e.getNpc().getId() == NpcID.AKKHAS_SHADOW)
+		{
+			shadows.add(e.getNpc());
+		}
+	}
+
+	@Subscribe
+	public void onNpcDespawned(NpcDespawned e)
+	{
+		if (e.getNpc().getId() == NpcID.AKKHAS_SHADOW)
+		{
+			shadows.remove(e.getNpc());
+		}
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		shadows.forEach((npc) ->
+		{
+			{
+				final Model m = npc.getModel();
+				final String text = "H: " + m.getOverrideHue() + " S: " + m.getOverrideSaturation() + " L: " + m.getOverrideLuminance() + " X: " + m.getOverrideAmount();
+				Point point = npc.getCanvasTextLocation(graphics, text, 0);
+				if (point != null)
+				{
+					point = new Point(point.getX(), point.getY() - 20);
+					OverlayUtil.renderTextLocation(graphics, point, text, Color.WHITE, 12, FontStyle.PLAIN.getFont(), true);
+				}
+			}
+
+			NpcOverrides overrides = npc.getModelOverrides();
+			if (overrides == null)
+			{
+				return;
+			}
+
+			StringBuilder sb = new StringBuilder();
+			if (overrides.getModelIds() != null)
+			{
+				sb.append("M: ");
+				sb.append(Arrays.toString(overrides.getModelIds()));
+			}
+			if (overrides.getColorToReplaceWith() != null)
+			{
+				sb.append("C: ");
+				sb.append(Arrays.toString(overrides.getColorToReplaceWith()));
+			}
+			if (overrides.getTextureToReplaceWith() != null)
+			{
+				sb.append("T: ");
+				sb.append(Arrays.toString(overrides.getTextureToReplaceWith()));
+			}
+
+			final String text = sb.toString();
+			Point point = npc.getCanvasTextLocation(graphics, text, 0);
+			if (point != null)
+			{
+				point = new Point(point.getX(), point.getY() + 20);
+				OverlayUtil.renderTextLocation(graphics, point, text, Color.WHITE, 12, FontStyle.PLAIN.getFont(), true);
+			}
+		});
+		return null;
+	}
+}

--- a/src/test/java/launcher/debugplugins/ToaDebugPlugin.java
+++ b/src/test/java/launcher/debugplugins/ToaDebugPlugin.java
@@ -3,6 +3,7 @@ package launcher.debugplugins;
 import ch.qos.logback.classic.Level;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import ch.qos.logback.classic.Logger;
@@ -22,6 +23,12 @@ public class ToaDebugPlugin extends Plugin
 	@Inject
 	private HetSolverDebugOverlay hetSolverDebugOverlay;
 
+	@Inject
+	private AkkhaShadowOverridesOverlay shadowOverridesOverlay;
+
+	@Inject
+	private EventBus eventBus;
+
 	@Override
 	protected void startUp()
 	{
@@ -29,12 +36,16 @@ public class ToaDebugPlugin extends Plugin
 		((Logger) LoggerFactory.getLogger("com.duckblade.osrs.toa")).setLevel(Level.DEBUG);
 
 		overlayManager.add(hetSolverDebugOverlay);
+		overlayManager.add(shadowOverridesOverlay);
+		eventBus.register(shadowOverridesOverlay);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
 		((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.DEBUG);
-		overlayManager.removeIf(o -> o instanceof HetSolverDebugOverlay);
+		overlayManager.remove(hetSolverDebugOverlay);
+		overlayManager.remove(shadowOverridesOverlay);
+		eventBus.unregister(shadowOverridesOverlay);
 	}
 }


### PR DESCRIPTION
This adds an overlay to Akkha's Shadows showing their remaining HP.

The built-in OpponentInfo plugin can only show a percentage because NPCManager does not know most raid npc's max hp (due to dynamic raid and path level scaling, presumably).

The overlay intends to help player's gauge if an attack will deal a killing blow to a Shadow (namely in conjunction with the customizable-xp-drops plugin, which shows how much damage you deal alongside xp drops).

![hp](https://github.com/LlemonDuck/tombs-of-amascut/assets/38548565/6fcd8569-0859-40c8-90d9-0079a13133a2)
