### PR TITLE
cleanup config

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -452,7 +452,7 @@ public interface TombsOfAmascutConfig extends Config
 		description = "<html>Either disables the feature or plays an audio file whenever the purple chest is opened." +
 			"<br/>The custom audio file should be named toa-chest.wav inside the .runelite/tombs-of-amascut folder</html>",
 		section = SECTION_BURIAL_TOMB,
-		position = 601
+		position = 0
 	)
 	default boolean chestAudioEnable()
 	{
@@ -469,7 +469,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Audio Volume",
 		description = "Adjusts how loud the chest audio is when played. 100 is no change to file volume.",
 		section = SECTION_BURIAL_TOMB,
-		position = 602
+		position = 1
 	)
 	default int chestAudioVolume()
 	{
@@ -481,7 +481,7 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigItem(
 		name = "Recolour White Chest",
 		description = "Recolour the white sarcophagus.",
-		position = 603,
+		position = 2,
 		keyName = SARCOPHAGUS_RECOLOR_WHITE,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -495,7 +495,7 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigItem(
 		name = "White Colour",
 		description = "Colour to replace the white sarcophagus.",
-		position = 604,
+		position = 3,
 		keyName = SARCOPHAGUS_WHITE_RECOLOR,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -510,7 +510,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Recolour Purple Chest (Mine)",
 		description = "Recolour the purple sarcophagus." +
 			"<br>When the loot is mine.",
-		position = 605,
+		position = 4,
 		keyName = SARCOPHAGUS_RECOLOR_MY_PURPLE,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -525,7 +525,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Purple Colour (Mine)",
 		description = "Colour to replace the purple sarcophagus." +
 			"<br>When the loot is mine.",
-		position = 606,
+		position = 5,
 		keyName = SARCOPHAGUS_MY_PURPLE_RECOLOR,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -540,7 +540,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Recolour Purple Chest (Other)",
 		description = "Recolour the purple sarcophagus." +
 			"<br>When the loot is NOT mine.",
-		position = 607,
+		position = 6,
 		keyName = SARCOPHAGUS_RECOLOR_OTHER_PURPLE,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -555,7 +555,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Purple Colour (Other)",
 		description = "Colour to replace the purple sarcophagus." +
 			"<br>When the loot is NOT mine.",
-		position = 608,
+		position = 7,
 		keyName = SARCOPHAGUS_OTHER_PURPLE_RECOLOR,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -568,7 +568,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Detect Cursed Phalanx",
 		description = "Prevents opening chests if player is carrying a cursed phalanx" +
 			"<br>or Osmumten's fang (or).",
-		position = 609,
+		position = 8,
 		keyName = "cursedPhalanxDetect",
 		section = SECTION_BURIAL_TOMB
 	)

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -298,7 +298,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Beam Timer",
 		description = "<html>Display an overlay of when the Caster Statue will fire." +
 			"<br/>Click Het's Seal from one tile away when the indicator is GREEN to get an extra damage tick.</html>",
-		position = 401,
+		position = 0,
 		section = SECTION_HET
 	)
 	default boolean hetBeamTimerEnable()
@@ -310,7 +310,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "hetSolverEnable",
 		name = "Mirror Puzzle Solver",
 		description = "Show where to place/clean mirrors for the active puzzle layout.",
-		position = 402,
+		position = 1,
 		section = SECTION_HET
 	)
 	default boolean hetSolverEnable()
@@ -324,7 +324,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = KEY_HET_PICKAXE_MENU_SWAP,
 		name = "Deposit-Pickaxe",
 		description = "Automatically swap to Deposit-pickaxe when a pickaxe is in your inventory.",
-		position = 403,
+		position = 2,
 		section = SECTION_HET
 	)
 	default boolean hetPickaxeMenuSwap()
@@ -338,7 +338,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = KEY_HET_PICKAXE_PREVENT_EXIT,
 		name = "Prevent Room Exit",
 		description = "Deprioritize the option to leave the puzzle room until you have deposited your pickaxe in the statue.",
-		position = 404,
+		position = 3,
 		section = SECTION_HET
 	)
 	default boolean hetPickaxePreventExit()
@@ -350,7 +350,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "hetPickaxePreventRaidStart",
 		name = "Prevent Raid Start",
 		description = "Deprioritize the option to enter the raid until you have deposited your pickaxe in the lobby wall cavity.",
-		position = 405,
+		position = 4,
 		section = SECTION_HET
 	)
 	default boolean hetPickaxePreventRaidStart()
@@ -362,7 +362,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "hetPickaxePuzzleOverlay",
 		name = "Puzzle Room Visual Warning",
 		description = "Add a visual warning reminder to deposit your pickaxe at the end of the mirror puzzle room.",
-		position = 406,
+		position = 5,
 		section = SECTION_HET
 	)
 	default boolean hetPickaxePuzzleOverlay()
@@ -374,7 +374,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "hetPickaxeLobbyOverlay",
 		name = "Lobby Visual Warning",
 		description = "Add a visual warning reminder to deposit your pickaxe in the raid lobby.",
-		position = 407,
+		position = 6,
 		section = SECTION_HET
 	)
 	default boolean hetPickaxeLobbyOverlay()

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -621,7 +621,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "apmekenWaveHelper",
 		name = "Apmeken Wave Helper",
 		description = "When entering the Path of Apmeken, displays a list of the waves in the RuneLite side panel.",
-		position = 801,
+		position = 0,
 		section = SECTION_MISCELLANEOUS
 	)
 	default boolean apmekenWaveHelper()
@@ -635,7 +635,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = KEY_QUICK_PROCEED_ENABLE_MODE,
 		name = "Quick Proceed",
 		description = "Left click proceed/begin/leave on Osmumten and quick-enter/quick-use entryways and teleport crystals.",
-		position = 802,
+		position = 1,
 		section = SECTION_MISCELLANEOUS
 	)
 	default QuickProceedEnableMode quickProceedEnableMode()
@@ -649,7 +649,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = KEY_HP_ORB_MODE,
 		name = "HP Orbs",
 		description = "Removes HP orbs from the screen or replaces them with health bars.",
-		position = 803,
+		position = 2,
 		section = SECTION_MISCELLANEOUS
 	)
 	default HpOrbMode hpOrbsMode()
@@ -661,7 +661,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "leftClickBankAll",
 		name = "Bank-all Single Click",
 		description = "Allows you to Bank-all loot without requiring a second click on the minimenu.",
-		position = 804,
+		position = 3,
 		section = SECTION_MISCELLANEOUS
 	)
 	default boolean leftClickBankAll()
@@ -673,7 +673,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "showUpdateMessages",
 		name = "Show Updates",
 		description = "Opens a panel describing plugin updates after new features are added to the plugin.",
-		position = 805,
+		position = 4,
 		section = SECTION_MISCELLANEOUS
 	)
 	default boolean showUpdateMessages()
@@ -685,7 +685,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "hideFadeTransition",
 		name = "Hide Fade Transition",
 		description = "Hides the fade transition between loading zones.",
-		position = 806,
+		position = 5,
 		section = SECTION_MISCELLANEOUS
 	)
 	default boolean hideFadeTransition()

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -27,9 +27,17 @@ public interface TombsOfAmascutConfig extends Config
 	// Sections
 
 	@ConfigSection(
+		name = "Miscellaneous",
+		description = "Miscellaneous configurations.",
+		position = 0,
+		closedByDefault = false
+	)
+	String SECTION_MISCELLANEOUS = "sectionMiscellaneous";
+
+	@ConfigSection(
 		name = "Akkha",
 		description = "Configuration for Akkha boss room.",
-		position = 0,
+		position = 1,
 		closedByDefault = true
 	)
 	String SECTION_AKKHA = "sectionAkkha";
@@ -37,7 +45,7 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Path of Apmeken",
 		description = "Options for the Path of Apmeken.",
-		position = 1,
+		position = 2,
 		closedByDefault = true
 	)
 	String SECTION_APMEKEN = "sectionApmeken";
@@ -45,7 +53,7 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Path of Het",
 		description = "Helpers for the Path of Het.",
-		position = 2,
+		position = 3,
 		closedByDefault = true
 	)
 	String SECTION_HET = "sectionHet";
@@ -53,7 +61,7 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Path of Scabaras",
 		description = "Options for the puzzles in the Path of Scabaras.",
-		position = 3,
+		position = 4,
 		closedByDefault = true
 	)
 	String SECTION_SCABARAS = "sectionScabaras";
@@ -61,15 +69,24 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Burial Tomb",
 		description = "Configuration for the burial tomb.",
-		position = 4,
+		position = 5,
 		closedByDefault = true
 	)
 	String SECTION_BURIAL_TOMB = "sectionBurialTomb";
 
 	@ConfigSection(
+		name = "Points Tracker",
+		description = "<html>Tracks points for the raid, used in calculating drop chance." +
+			"<br/>NOTE: For teams, you MUST use the RuneLite Party plugin to receive team drop chance.</html>",
+		position = 6,
+		closedByDefault = true
+	)
+	String SECTION_POINTS_TRACKER = "sectionPointsTracker";
+
+	@ConfigSection(
 		name = "Invocation Presets",
 		description = "Save presets of invocations to quickly restore your invocations between runs of different types.",
-		position = 5,
+		position = 7,
 		closedByDefault = true
 	)
 	String SECTION_INVOCATION_PRESETS = "invocationPresetsSection";
@@ -77,35 +94,18 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Invocation Screenshot",
 		description = "All config options related to the Invocation Screenshot functionality",
-		position = 6,
+		position = 8,
 		closedByDefault = true
 	)
 	String SECTION_INVOCATION_SCREENSHOT = "invocationScreenshotSection";
 
 	@ConfigSection(
-		name = "Points Tracker",
-		description = "<html>Tracks points for the raid, used in calculating drop chance." +
-			"<br/>NOTE: For teams, you MUST use the RuneLite Party plugin to receive team drop chance.</html>",
-		position = 7,
-		closedByDefault = true
-	)
-	String SECTION_POINTS_TRACKER = "sectionPointsTracker";
-
-	@ConfigSection(
 		name = "Time Tracking",
 		description = "Time tracking and splits.",
-		position = 8,
-		closedByDefault = true
-	)
-	String SECTION_TIME_TRACKING = "sectionTimeTracking";
-
-	@ConfigSection(
-		name = "Miscellaneous",
-		description = "Miscellaneous configurations.",
 		position = 9,
 		closedByDefault = true
 	)
-	String SECTION_MISCELLANEOUS = "sectionMiscellaneous";
+	String SECTION_TIME_TRACKING = "sectionTimeTracking";
 
 	// Akkha
 
@@ -508,12 +508,24 @@ public interface TombsOfAmascutConfig extends Config
 	// Burial Tomb
 
 	@ConfigItem(
+		keyName = "leftClickBankAll",
+		name = "Bank-all Single Click",
+		description = "Allows you to Bank-all loot without requiring a second click on the minimenu.",
+		section = SECTION_BURIAL_TOMB,
+		position = 0
+	)
+	default boolean leftClickBankAll()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "chestAudioEnable",
 		name = "Purple Chest Audio",
 		description = "<html>Either disables the feature or plays an audio file whenever the purple chest is opened." +
 			"<br/>The custom audio file should be named toa-chest.wav inside the .runelite/tombs-of-amascut folder</html>",
 		section = SECTION_BURIAL_TOMB,
-		position = 0
+		position = 1
 	)
 	default boolean chestAudioEnable()
 	{
@@ -530,7 +542,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Audio Volume",
 		description = "Adjusts how loud the chest audio is when played. 100 is no change to file volume.",
 		section = SECTION_BURIAL_TOMB,
-		position = 1
+		position = 2
 	)
 	default int chestAudioVolume()
 	{
@@ -542,7 +554,7 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigItem(
 		name = "Recolour White Chest",
 		description = "Recolour the white sarcophagus.",
-		position = 2,
+		position = 3,
 		keyName = SARCOPHAGUS_RECOLOR_WHITE,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -556,7 +568,7 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigItem(
 		name = "White Colour",
 		description = "Colour to replace the white sarcophagus.",
-		position = 3,
+		position = 4,
 		keyName = SARCOPHAGUS_WHITE_RECOLOR,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -571,7 +583,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Recolour Purple Chest (Mine)",
 		description = "Recolour the purple sarcophagus." +
 			"<br>When the loot is mine.",
-		position = 4,
+		position = 5,
 		keyName = SARCOPHAGUS_RECOLOR_MY_PURPLE,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -586,7 +598,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Purple Colour (Mine)",
 		description = "Colour to replace the purple sarcophagus." +
 			"<br>When the loot is mine.",
-		position = 5,
+		position = 6,
 		keyName = SARCOPHAGUS_MY_PURPLE_RECOLOR,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -601,7 +613,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Recolour Purple Chest (Other)",
 		description = "Recolour the purple sarcophagus." +
 			"<br>When the loot is NOT mine.",
-		position = 6,
+		position = 7,
 		keyName = SARCOPHAGUS_RECOLOR_OTHER_PURPLE,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -616,7 +628,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Purple Colour (Other)",
 		description = "Colour to replace the purple sarcophagus." +
 			"<br>When the loot is NOT mine.",
-		position = 7,
+		position = 8,
 		keyName = SARCOPHAGUS_OTHER_PURPLE_RECOLOR,
 		section = SECTION_BURIAL_TOMB
 	)
@@ -629,7 +641,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Detect Cursed Phalanx",
 		description = "Prevents opening chests if player is carrying a cursed phalanx" +
 			"<br>or Osmumten's fang (or).",
-		position = 8,
+		position = 9,
 		keyName = "cursedPhalanxDetect",
 		section = SECTION_BURIAL_TOMB
 	)
@@ -641,7 +653,7 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigItem(
 		name = "Track Purple Dry Count",
 		description = "Show purple dry streak count in chat upon raid completion.",
-		position = 9,
+		position = 10,
 		keyName = "trackPurpleDryCount",
 		section = SECTION_BURIAL_TOMB
 	)
@@ -842,18 +854,6 @@ public interface TombsOfAmascutConfig extends Config
 	default HpOrbMode hpOrbsMode()
 	{
 		return HpOrbMode.ORBS;
-	}
-
-	@ConfigItem(
-		keyName = "leftClickBankAll",
-		name = "Bank-all Single Click",
-		description = "Allows you to Bank-all loot without requiring a second click on the minimenu.",
-		position = 2,
-		section = SECTION_MISCELLANEOUS
-	)
-	default boolean leftClickBankAll()
-	{
-		return false;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -158,7 +158,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "scabarasHelperMode",
 		name = "Scabaras Helpers",
 		description = "Puzzle helpers for the Path of Scabaras (leading to Kephri).",
-		position = 301,
+		position = 0,
 		section = SECTION_SCABARAS
 	)
 	default ScabarasHelperMode scabarasHelperMode()
@@ -171,7 +171,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Addition Colour",
 		description = "Highlight colour for tiles in the addition puzzle." +
 			"<br/>Set alpha to 0 to disable.",
-		position = 302,
+		position = 1,
 		section = SECTION_SCABARAS
 	)
 	@Alpha
@@ -185,7 +185,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Light Flip Colour",
 		description = "Highlight colour for tiles in the light flips puzzle." +
 			"<br/>Set alpha to 0 to disable.",
-		position = 303,
+		position = 2,
 		section = SECTION_SCABARAS
 	)
 	@Alpha
@@ -199,7 +199,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Obelisk Start",
 		description = "Start colour for highlighting the obelisks in the obelisk puzzle." +
 			"<br/>Set alpha to 0 to disable.",
-		position = 304,
+		position = 3,
 		section = SECTION_SCABARAS
 	)
 	@Alpha
@@ -213,7 +213,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Obelisk End",
 		description = "End colour for highlighting the obelisks in the obelisk puzzle." +
 			"<br/>Set alpha to 0 to disable.",
-		position = 305,
+		position = 4,
 		section = SECTION_SCABARAS
 	)
 	@Alpha
@@ -227,7 +227,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Sequence Start",
 		description = "Start colour for highlighting the tiles in the sequence (simon says) puzzle." +
 			"<br/>Set alpha to 0 to disable.",
-		position = 306,
+		position = 5,
 		section = SECTION_SCABARAS
 	)
 	@Alpha
@@ -241,7 +241,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Sequence End",
 		description = "End colour for highlighting the tiles in the sequence (simon says) puzzle." +
 			"<br/>Set alpha to 0 to disable.",
-		position = 307,
+		position = 6,
 		section = SECTION_SCABARAS
 	)
 	@Alpha
@@ -254,7 +254,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "scabarasMatchingDisplayMode",
 		name = "Matching Display",
 		description = "Whether to show highlight tiles, show names of tiles, or both for the matching puzzle.",
-		position = 308,
+		position = 7,
 		section = SECTION_SCABARAS
 	)
 	default MatchingTileDisplayMode scabarasMatchingDisplayMode()
@@ -267,7 +267,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Matched Opacity",
 		description = "Opacity (transparency) of completed tiles in the matching puzzle." +
 			"<br/>Set to 0 to hide completed tiles completely.",
-		position = 309,
+		position = 8,
 		section = SECTION_SCABARAS
 	)
 	@Range(
@@ -283,7 +283,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "scabarasHighlightSkipObeliskEntry",
 		name = "Show Obelisk Skip",
 		description = "Highlight which entrance will skip requiring the obelisk puzzle.",
-		position = 310,
+		position = 9,
 		section = SECTION_SCABARAS
 	)
 	default SkipObeliskOverlay.EnableMode scabarasHighlightSkipObeliskEntry()

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -93,7 +93,8 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Invocation Presets",
 		description = "Save presets of invocations to quickly restore your invocations between runs of different types.",
-		position = 100
+		position = 100,
+		closedByDefault = true
 	)
 	String SECTION_INVOCATION_PRESETS = "invocationPresetsSection";
 
@@ -124,8 +125,8 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Invocation Screenshot",
 		description = "All config options related to the Invocation Screenshot functionality",
-		closedByDefault = true,
-		position = 200
+		position = 200,
+		closedByDefault = true
 	)
 	String SECTION_INVOCATION_SCREENSHOT = "invocationScreenshotSection";
 
@@ -168,7 +169,8 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Path of Scabaras",
 		description = "Options for the puzzles in the Path of Scabaras.",
-		position = 300
+		position = 300,
+		closedByDefault = true
 	)
 	String SECTION_SCABARAS = "sectionScabaras";
 
@@ -312,7 +314,8 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Path of Het",
 		description = "Helpers for the Path of Het.",
-		position = 400
+		position = 400,
+		closedByDefault = true
 	)
 	String SECTION_HET = "sectionHet";
 
@@ -409,7 +412,8 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Points Tracker",
 		description = "<html>Tracks points for the raid, used in calculating drop chance." +
 			"<br/>NOTE: For teams, you MUST use the RuneLite Party plugin to receive team drop chance.</html>",
-		position = 500
+		position = 500,
+		closedByDefault = true
 	)
 	String SECTION_POINTS_TRACKER = "sectionPointsTracker";
 
@@ -615,8 +619,8 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Time Tracking",
 		description = "Time tracking and splits.",
-		closedByDefault = true,
-		position = 700
+		position = 700,
+		closedByDefault = true
 	)
 	String SECTION_TIME_TRACKING = "sectionTimeTracking";
 

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -21,74 +21,7 @@ public interface TombsOfAmascutConfig extends Config
 
 	String CONFIG_GROUP = "tombsofamascut";
 
-	@ConfigItem(
-		keyName = "apmekenWaveHelper",
-		name = "Apmeken Wave Helper",
-		description = "When entering the Path of Apmeken, displays a list of the waves in the RuneLite side panel.",
-		position = 3
-	)
-	default boolean apmekenWaveHelper()
-	{
-		return true;
-	}
-
-	String KEY_QUICK_PROCEED_ENABLE_MODE = "quickProceedEnableMode";
-
-	@ConfigItem(
-		keyName = KEY_QUICK_PROCEED_ENABLE_MODE,
-		name = "Quick Proceed",
-		description = "Left click proceed/begin/leave on Osmumten and quick-enter/quick-use entryways and teleport crystals.",
-		position = 5
-	)
-	default QuickProceedEnableMode quickProceedEnableMode()
-	{
-		return QuickProceedEnableMode.ALL;
-	}
-
-	String KEY_HP_ORB_MODE = "hpOrbsMode";
-	@ConfigItem(
-		keyName = KEY_HP_ORB_MODE,
-		name = "HP Orbs",
-		description = "Removes HP orbs from the screen or replaces them with health bars.",
-		position = 6
-	)
-	default HpOrbMode hpOrbsMode()
-	{
-		return HpOrbMode.ORBS;
-	}
-
-	@ConfigItem(
-		keyName = "leftClickBankAll",
-		name = "Bank-all Single Click",
-		description = "Allows you to Bank-all loot without requiring a second click on the minimenu.",
-		position = 7
-	)
-	default boolean leftClickBankAll()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "showUpdateMessages",
-		name = "Show Updates",
-		description = "Opens a panel describing plugin updates after new features are added to the plugin.",
-		position = 7
-	)
-	default boolean showUpdateMessages()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "hideFadeTransition",
-		name = "Hide Fade Transition",
-		description = "Hides the fade transition between loading zones.",
-		position = 9
-	)
-	default boolean hideFadeTransition()
-	{
-		return false;
-	}
+	// Sections
 
 	@ConfigSection(
 		name = "Invocation Presets",
@@ -97,6 +30,65 @@ public interface TombsOfAmascutConfig extends Config
 		closedByDefault = true
 	)
 	String SECTION_INVOCATION_PRESETS = "invocationPresetsSection";
+
+	@ConfigSection(
+		name = "Invocation Screenshot",
+		description = "All config options related to the Invocation Screenshot functionality",
+		position = 200,
+		closedByDefault = true
+	)
+	String SECTION_INVOCATION_SCREENSHOT = "invocationScreenshotSection";
+
+	@ConfigSection(
+		name = "Path of Scabaras",
+		description = "Options for the puzzles in the Path of Scabaras.",
+		position = 300,
+		closedByDefault = true
+	)
+	String SECTION_SCABARAS = "sectionScabaras";
+
+	@ConfigSection(
+		name = "Path of Het",
+		description = "Helpers for the Path of Het.",
+		position = 400,
+		closedByDefault = true
+	)
+	String SECTION_HET = "sectionHet";
+
+	@ConfigSection(
+		name = "Points Tracker",
+		description = "<html>Tracks points for the raid, used in calculating drop chance." +
+			"<br/>NOTE: For teams, you MUST use the RuneLite Party plugin to receive team drop chance.</html>",
+		position = 500,
+		closedByDefault = true
+	)
+	String SECTION_POINTS_TRACKER = "sectionPointsTracker";
+
+	@ConfigSection(
+		name = "Burial Tomb",
+		description = "Configuration for the burial tomb.",
+		position = 600,
+		closedByDefault = true
+	)
+	String SECTION_BURIAL_TOMB = "sectionBurialTomb";
+
+	@ConfigSection(
+		name = "Time Tracking",
+		description = "Time tracking and splits.",
+		position = 700,
+		closedByDefault = true
+	)
+	String SECTION_TIME_TRACKING = "sectionTimeTracking";
+
+	@ConfigSection(
+		name = "Miscellaneous",
+		description = "Miscellaneous configurations.",
+		position = 800,
+		closedByDefault = true
+	)
+	String SECTION_MISCELLANEOUS = "sectionMiscellaneous";
+
+	// Invocation Presets
 
 	@ConfigItem(
 		keyName = "invocationPresetsEnable",
@@ -122,13 +114,7 @@ public interface TombsOfAmascutConfig extends Config
 		return true;
 	}
 
-	@ConfigSection(
-		name = "Invocation Screenshot",
-		description = "All config options related to the Invocation Screenshot functionality",
-		position = 200,
-		closedByDefault = true
-	)
-	String SECTION_INVOCATION_SCREENSHOT = "invocationScreenshotSection";
+	// Invocation Screenshot
 
 	@ConfigItem(
 		keyName = "invocationScreenshotEnable",
@@ -166,13 +152,7 @@ public interface TombsOfAmascutConfig extends Config
 		return true;
 	}
 
-	@ConfigSection(
-		name = "Path of Scabaras",
-		description = "Options for the puzzles in the Path of Scabaras.",
-		position = 300,
-		closedByDefault = true
-	)
-	String SECTION_SCABARAS = "sectionScabaras";
+	// Scabaras
 
 	@ConfigItem(
 		keyName = "scabarasHelperMode",
@@ -311,13 +291,7 @@ public interface TombsOfAmascutConfig extends Config
 		return SkipObeliskOverlay.EnableMode.OFF;
 	}
 
-	@ConfigSection(
-		name = "Path of Het",
-		description = "Helpers for the Path of Het.",
-		position = 400,
-		closedByDefault = true
-	)
-	String SECTION_HET = "sectionHet";
+	// Het
 
 	@ConfigItem(
 		keyName = "hetBeamTimerEnable",
@@ -408,14 +382,7 @@ public interface TombsOfAmascutConfig extends Config
 		return false;
 	}
 
-	@ConfigSection(
-		name = "Points Tracker",
-		description = "<html>Tracks points for the raid, used in calculating drop chance." +
-			"<br/>NOTE: For teams, you MUST use the RuneLite Party plugin to receive team drop chance.</html>",
-		position = 500,
-		closedByDefault = true
-	)
-	String SECTION_POINTS_TRACKER = "sectionPointsTracker";
+	// Points Tracker
 
 	@ConfigItem(
 		keyName = "pointsTrackerOverlayEnable",
@@ -477,13 +444,7 @@ public interface TombsOfAmascutConfig extends Config
 		return true;
 	}
 
-	@ConfigSection(
-		name = "Burial Tomb",
-		description = "Configuration for the burial tomb.",
-		position = 600,
-		closedByDefault = true
-	)
-	String SECTION_BURIAL_TOMB = "sectionBurialTomb";
+	// Burial Tomb
 
 	@ConfigItem(
 		keyName = "chestAudioEnable",
@@ -616,13 +577,7 @@ public interface TombsOfAmascutConfig extends Config
 		return false;
 	}
 
-	@ConfigSection(
-		name = "Time Tracking",
-		description = "Time tracking and splits.",
-		position = 700,
-		closedByDefault = true
-	)
-	String SECTION_TIME_TRACKING = "sectionTimeTracking";
+	// Time Tracking
 
 	@ConfigItem(
 		keyName = "targetTimeDisplay",
@@ -659,6 +614,86 @@ public interface TombsOfAmascutConfig extends Config
 	{
 		return SplitsMode.OFF;
 	}
+
+	// Miscellaneous
+
+	@ConfigItem(
+		keyName = "apmekenWaveHelper",
+		name = "Apmeken Wave Helper",
+		description = "When entering the Path of Apmeken, displays a list of the waves in the RuneLite side panel.",
+		position = 801,
+		section = SECTION_MISCELLANEOUS
+	)
+	default boolean apmekenWaveHelper()
+	{
+		return true;
+	}
+
+	String KEY_QUICK_PROCEED_ENABLE_MODE = "quickProceedEnableMode";
+
+	@ConfigItem(
+		keyName = KEY_QUICK_PROCEED_ENABLE_MODE,
+		name = "Quick Proceed",
+		description = "Left click proceed/begin/leave on Osmumten and quick-enter/quick-use entryways and teleport crystals.",
+		position = 802,
+		section = SECTION_MISCELLANEOUS
+	)
+	default QuickProceedEnableMode quickProceedEnableMode()
+	{
+		return QuickProceedEnableMode.ALL;
+	}
+
+	String KEY_HP_ORB_MODE = "hpOrbsMode";
+
+	@ConfigItem(
+		keyName = KEY_HP_ORB_MODE,
+		name = "HP Orbs",
+		description = "Removes HP orbs from the screen or replaces them with health bars.",
+		position = 803,
+		section = SECTION_MISCELLANEOUS
+	)
+	default HpOrbMode hpOrbsMode()
+	{
+		return HpOrbMode.ORBS;
+	}
+
+	@ConfigItem(
+		keyName = "leftClickBankAll",
+		name = "Bank-all Single Click",
+		description = "Allows you to Bank-all loot without requiring a second click on the minimenu.",
+		position = 804,
+		section = SECTION_MISCELLANEOUS
+	)
+	default boolean leftClickBankAll()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showUpdateMessages",
+		name = "Show Updates",
+		description = "Opens a panel describing plugin updates after new features are added to the plugin.",
+		position = 805,
+		section = SECTION_MISCELLANEOUS
+	)
+	default boolean showUpdateMessages()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "hideFadeTransition",
+		name = "Hide Fade Transition",
+		description = "Hides the fade transition between loading zones.",
+		position = 806,
+		section = SECTION_MISCELLANEOUS
+	)
+	default boolean hideFadeTransition()
+	{
+		return false;
+	}
+
+	// Hidden
 
 	@ConfigItem(
 		keyName = "updateNotifierLastVersion",

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -583,7 +583,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "targetTimeDisplay",
 		name = "Target Time in Timer",
 		description = "Expand the in-raid timer to also show the target time to beat.",
-		position = 701,
+		position = 0,
 		section = SECTION_TIME_TRACKING
 	)
 	default boolean targetTimeDisplay()
@@ -595,7 +595,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "splitsMessage",
 		name = "Splits Post-Raid Message",
 		description = "Show room splits in a chat message at the end of the raid. Path shows boss completion times, room shows each individual room (can be very long).",
-		position = 702,
+		position = 1,
 		section = SECTION_TIME_TRACKING
 	)
 	default SplitsMode splitsMessage()
@@ -607,7 +607,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "splitsOverlay",
 		name = "Splits Overlay",
 		description = "Show room splits in an on-screen overlay. Path shows boss completion times, room shows each individual room (can be very long).",
-		position = 703,
+		position = 2,
 		section = SECTION_TIME_TRACKING
 	)
 	default SplitsMode splitsOverlay()

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -88,68 +88,95 @@ public interface TombsOfAmascutConfig extends Config
 	)
 	String SECTION_MISCELLANEOUS = "sectionMiscellaneous";
 
-	// Invocation Presets
+	// Het
 
 	@ConfigItem(
-		keyName = "invocationPresetsEnable",
-		name = "Enable Presets",
-		description = "Allows for saving and restoring of invocation presets. Right-click \"Preset\" button to save/load.",
-		section = SECTION_INVOCATION_PRESETS,
-		position = 0
+		keyName = "hetBeamTimerEnable",
+		name = "Beam Timer",
+		description = "<html>Display an overlay of when the Caster Statue will fire." +
+			"<br/>Click Het's Seal from one tile away when the indicator is GREEN to get an extra damage tick.</html>",
+		position = 0,
+		section = SECTION_HET
 	)
-	default boolean invocationPresetsEnable()
+	default boolean hetBeamTimerEnable()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "hetSolverEnable",
+		name = "Mirror Puzzle Solver",
+		description = "Show where to place/clean mirrors for the active puzzle layout.",
+		position = 1,
+		section = SECTION_HET
+	)
+	default boolean hetSolverEnable()
+	{
+		return true;
+	}
+
+	String KEY_HET_PICKAXE_MENU_SWAP = "hetPickaxeMenuSwap";
+
+	@ConfigItem(
+		keyName = KEY_HET_PICKAXE_MENU_SWAP,
+		name = "Deposit-Pickaxe",
+		description = "Automatically swap to Deposit-pickaxe when a pickaxe is in your inventory.",
+		position = 2,
+		section = SECTION_HET
+	)
+	default boolean hetPickaxeMenuSwap()
+	{
+		return true;
+	}
+
+	String KEY_HET_PICKAXE_PREVENT_EXIT = "hetPickaxePreventExit";
+
+	@ConfigItem(
+		keyName = KEY_HET_PICKAXE_PREVENT_EXIT,
+		name = "Prevent Room Exit",
+		description = "Deprioritize the option to leave the puzzle room until you have deposited your pickaxe in the statue.",
+		position = 3,
+		section = SECTION_HET
+	)
+	default boolean hetPickaxePreventExit()
 	{
 		return false;
 	}
 
 	@ConfigItem(
-		keyName = "invocationPresetsScroll",
-		name = "Auto-Scroll",
-		description = "Automatically scroll to invocations which need to be changed for the current preset.",
-		section = SECTION_INVOCATION_PRESETS,
-		position = 1
+		keyName = "hetPickaxePreventRaidStart",
+		name = "Prevent Raid Start",
+		description = "Deprioritize the option to enter the raid until you have deposited your pickaxe in the lobby wall cavity.",
+		position = 4,
+		section = SECTION_HET
 	)
-	default boolean invocationPresetsScroll()
+	default boolean hetPickaxePreventRaidStart()
 	{
-		return true;
-	}
-
-	// Invocation Screenshot
-
-	@ConfigItem(
-		keyName = "invocationScreenshotEnable",
-		name = "Enable Screenshot button",
-		description = "Adds a button to the ToA Invocation interface that will copy all invocations as an image to your system clipboard",
-		section = SECTION_INVOCATION_SCREENSHOT,
-		position = 0
-	)
-	default boolean invocationScreenshotEnable()
-	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
-		keyName = "showRewardsSection",
-		name = "Show Rewards Section",
-		description = "<html>Should the rewards section be included<br/>(requires the Reward button to be selected within the interface)</html>",
-		section = SECTION_INVOCATION_SCREENSHOT,
-		position = 1
+		keyName = "hetPickaxePuzzleOverlay",
+		name = "Puzzle Room Visual Warning",
+		description = "Add a visual warning reminder to deposit your pickaxe at the end of the mirror puzzle room.",
+		position = 5,
+		section = SECTION_HET
 	)
-	default boolean showRewardsSection()
+	default boolean hetPickaxePuzzleOverlay()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
-		keyName = "useResourcePack",
-		name = "Use Resource Pack",
-		description = "Use Resource Pack Theme for screenshot background",
-		section = SECTION_INVOCATION_SCREENSHOT,
-		position = 2
+		keyName = "hetPickaxeLobbyOverlay",
+		name = "Lobby Visual Warning",
+		description = "Add a visual warning reminder to deposit your pickaxe in the raid lobby.",
+		position = 6,
+		section = SECTION_HET
 	)
-	default boolean useResourcePack()
+	default boolean hetPickaxeLobbyOverlay()
 	{
-		return true;
+		return false;
 	}
 
 	// Scabaras
@@ -291,159 +318,6 @@ public interface TombsOfAmascutConfig extends Config
 		return SkipObeliskOverlay.EnableMode.OFF;
 	}
 
-	// Het
-
-	@ConfigItem(
-		keyName = "hetBeamTimerEnable",
-		name = "Beam Timer",
-		description = "<html>Display an overlay of when the Caster Statue will fire." +
-			"<br/>Click Het's Seal from one tile away when the indicator is GREEN to get an extra damage tick.</html>",
-		position = 0,
-		section = SECTION_HET
-	)
-	default boolean hetBeamTimerEnable()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "hetSolverEnable",
-		name = "Mirror Puzzle Solver",
-		description = "Show where to place/clean mirrors for the active puzzle layout.",
-		position = 1,
-		section = SECTION_HET
-	)
-	default boolean hetSolverEnable()
-	{
-		return true;
-	}
-
-	String KEY_HET_PICKAXE_MENU_SWAP = "hetPickaxeMenuSwap";
-
-	@ConfigItem(
-		keyName = KEY_HET_PICKAXE_MENU_SWAP,
-		name = "Deposit-Pickaxe",
-		description = "Automatically swap to Deposit-pickaxe when a pickaxe is in your inventory.",
-		position = 2,
-		section = SECTION_HET
-	)
-	default boolean hetPickaxeMenuSwap()
-	{
-		return true;
-	}
-
-	String KEY_HET_PICKAXE_PREVENT_EXIT = "hetPickaxePreventExit";
-
-	@ConfigItem(
-		keyName = KEY_HET_PICKAXE_PREVENT_EXIT,
-		name = "Prevent Room Exit",
-		description = "Deprioritize the option to leave the puzzle room until you have deposited your pickaxe in the statue.",
-		position = 3,
-		section = SECTION_HET
-	)
-	default boolean hetPickaxePreventExit()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "hetPickaxePreventRaidStart",
-		name = "Prevent Raid Start",
-		description = "Deprioritize the option to enter the raid until you have deposited your pickaxe in the lobby wall cavity.",
-		position = 4,
-		section = SECTION_HET
-	)
-	default boolean hetPickaxePreventRaidStart()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "hetPickaxePuzzleOverlay",
-		name = "Puzzle Room Visual Warning",
-		description = "Add a visual warning reminder to deposit your pickaxe at the end of the mirror puzzle room.",
-		position = 5,
-		section = SECTION_HET
-	)
-	default boolean hetPickaxePuzzleOverlay()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "hetPickaxeLobbyOverlay",
-		name = "Lobby Visual Warning",
-		description = "Add a visual warning reminder to deposit your pickaxe in the raid lobby.",
-		position = 6,
-		section = SECTION_HET
-	)
-	default boolean hetPickaxeLobbyOverlay()
-	{
-		return false;
-	}
-
-	// Points Tracker
-
-	@ConfigItem(
-		keyName = "pointsTrackerOverlayEnable",
-		name = "Enable Overlay",
-		description = "Show points earned within the raid.",
-		position = 0,
-		section = SECTION_POINTS_TRACKER
-	)
-	default boolean pointsTrackerOverlayEnable()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "pointsTrackerShowRoomPoints",
-		name = "Separate Room Points",
-		description = "Show points for the current room separate from total points.",
-		position = 1,
-		section = SECTION_POINTS_TRACKER
-	)
-	default boolean pointsTrackerShowRoomPoints()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "pointsTrackerShowUniqueChance",
-		name = "Show Unique %",
-		description = "Show unique chance on the overlay.",
-		position = 2,
-		section = SECTION_POINTS_TRACKER
-	)
-	default boolean pointsTrackerShowUniqueChance()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "pointsTrackerShowPetChance",
-		name = "Show Pet %",
-		description = "Show pet chance on the overlay.",
-		position = 3,
-		section = SECTION_POINTS_TRACKER
-	)
-	default boolean pointsTrackerShowPetChance()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "pointsTrackerPostRaidMessage",
-		name = "Points Total Message",
-		description = "Show the total points in chat after the raid, akin to the Chambers of Xeric.",
-		position = 4,
-		section = SECTION_POINTS_TRACKER
-	)
-	default boolean pointsTrackerPostRaidMessage()
-	{
-		return true;
-	}
-
 	// Burial Tomb
 
 	@ConfigItem(
@@ -575,6 +449,132 @@ public interface TombsOfAmascutConfig extends Config
 	default boolean cursedPhalanxDetect()
 	{
 		return false;
+	}
+
+	// Invocation Presets
+
+	@ConfigItem(
+		keyName = "invocationPresetsEnable",
+		name = "Enable Presets",
+		description = "Allows for saving and restoring of invocation presets. Right-click \"Preset\" button to save/load.",
+		section = SECTION_INVOCATION_PRESETS,
+		position = 0
+	)
+	default boolean invocationPresetsEnable()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "invocationPresetsScroll",
+		name = "Auto-Scroll",
+		description = "Automatically scroll to invocations which need to be changed for the current preset.",
+		section = SECTION_INVOCATION_PRESETS,
+		position = 1
+	)
+	default boolean invocationPresetsScroll()
+	{
+		return true;
+	}
+
+	// Invocation Screenshot
+
+	@ConfigItem(
+		keyName = "invocationScreenshotEnable",
+		name = "Enable Screenshot button",
+		description = "Adds a button to the ToA Invocation interface that will copy all invocations as an image to your system clipboard",
+		section = SECTION_INVOCATION_SCREENSHOT,
+		position = 0
+	)
+	default boolean invocationScreenshotEnable()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showRewardsSection",
+		name = "Show Rewards Section",
+		description = "<html>Should the rewards section be included<br/>(requires the Reward button to be selected within the interface)</html>",
+		section = SECTION_INVOCATION_SCREENSHOT,
+		position = 1
+	)
+	default boolean showRewardsSection()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "useResourcePack",
+		name = "Use Resource Pack",
+		description = "Use Resource Pack Theme for screenshot background",
+		section = SECTION_INVOCATION_SCREENSHOT,
+		position = 2
+	)
+	default boolean useResourcePack()
+	{
+		return true;
+	}
+
+	// Points Tracker
+
+	@ConfigItem(
+		keyName = "pointsTrackerOverlayEnable",
+		name = "Enable Overlay",
+		description = "Show points earned within the raid.",
+		position = 0,
+		section = SECTION_POINTS_TRACKER
+	)
+	default boolean pointsTrackerOverlayEnable()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "pointsTrackerShowRoomPoints",
+		name = "Separate Room Points",
+		description = "Show points for the current room separate from total points.",
+		position = 1,
+		section = SECTION_POINTS_TRACKER
+	)
+	default boolean pointsTrackerShowRoomPoints()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "pointsTrackerShowUniqueChance",
+		name = "Show Unique %",
+		description = "Show unique chance on the overlay.",
+		position = 2,
+		section = SECTION_POINTS_TRACKER
+	)
+	default boolean pointsTrackerShowUniqueChance()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "pointsTrackerShowPetChance",
+		name = "Show Pet %",
+		description = "Show pet chance on the overlay.",
+		position = 3,
+		section = SECTION_POINTS_TRACKER
+	)
+	default boolean pointsTrackerShowPetChance()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "pointsTrackerPostRaidMessage",
+		name = "Points Total Message",
+		description = "Show the total points in chat after the raid, akin to the Chambers of Xeric.",
+		position = 4,
+		section = SECTION_POINTS_TRACKER
+	)
+	default boolean pointsTrackerPostRaidMessage()
+	{
+		return true;
 	}
 
 	// Time Tracking

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -95,7 +95,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Enable Presets",
 		description = "Allows for saving and restoring of invocation presets. Right-click \"Preset\" button to save/load.",
 		section = SECTION_INVOCATION_PRESETS,
-		position = 101
+		position = 0
 	)
 	default boolean invocationPresetsEnable()
 	{
@@ -107,7 +107,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Auto-Scroll",
 		description = "Automatically scroll to invocations which need to be changed for the current preset.",
 		section = SECTION_INVOCATION_PRESETS,
-		position = 102
+		position = 1
 	)
 	default boolean invocationPresetsScroll()
 	{
@@ -121,7 +121,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Enable Screenshot button",
 		description = "Adds a button to the ToA Invocation interface that will copy all invocations as an image to your system clipboard",
 		section = SECTION_INVOCATION_SCREENSHOT,
-		position = 201
+		position = 0
 	)
 	default boolean invocationScreenshotEnable()
 	{
@@ -133,7 +133,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Show Rewards Section",
 		description = "<html>Should the rewards section be included<br/>(requires the Reward button to be selected within the interface)</html>",
 		section = SECTION_INVOCATION_SCREENSHOT,
-		position = 202
+		position = 1
 	)
 	default boolean showRewardsSection()
 	{
@@ -145,7 +145,7 @@ public interface TombsOfAmascutConfig extends Config
 		name = "Use Resource Pack",
 		description = "Use Resource Pack Theme for screenshot background",
 		section = SECTION_INVOCATION_SCREENSHOT,
-		position = 203
+		position = 2
 	)
 	default boolean useResourcePack()
 	{

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -24,9 +24,33 @@ public interface TombsOfAmascutConfig extends Config
 	// Sections
 
 	@ConfigSection(
+		name = "Path of Het",
+		description = "Helpers for the Path of Het.",
+		position = 0,
+		closedByDefault = true
+	)
+	String SECTION_HET = "sectionHet";
+
+	@ConfigSection(
+		name = "Path of Scabaras",
+		description = "Options for the puzzles in the Path of Scabaras.",
+		position = 1,
+		closedByDefault = true
+	)
+	String SECTION_SCABARAS = "sectionScabaras";
+
+	@ConfigSection(
+		name = "Burial Tomb",
+		description = "Configuration for the burial tomb.",
+		position = 2,
+		closedByDefault = true
+	)
+	String SECTION_BURIAL_TOMB = "sectionBurialTomb";
+
+	@ConfigSection(
 		name = "Invocation Presets",
 		description = "Save presets of invocations to quickly restore your invocations between runs of different types.",
-		position = 100,
+		position = 3,
 		closedByDefault = true
 	)
 	String SECTION_INVOCATION_PRESETS = "invocationPresetsSection";
@@ -34,48 +58,24 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Invocation Screenshot",
 		description = "All config options related to the Invocation Screenshot functionality",
-		position = 200,
+		position = 4,
 		closedByDefault = true
 	)
 	String SECTION_INVOCATION_SCREENSHOT = "invocationScreenshotSection";
 
 	@ConfigSection(
-		name = "Path of Scabaras",
-		description = "Options for the puzzles in the Path of Scabaras.",
-		position = 300,
-		closedByDefault = true
-	)
-	String SECTION_SCABARAS = "sectionScabaras";
-
-	@ConfigSection(
-		name = "Path of Het",
-		description = "Helpers for the Path of Het.",
-		position = 400,
-		closedByDefault = true
-	)
-	String SECTION_HET = "sectionHet";
-
-	@ConfigSection(
 		name = "Points Tracker",
 		description = "<html>Tracks points for the raid, used in calculating drop chance." +
 			"<br/>NOTE: For teams, you MUST use the RuneLite Party plugin to receive team drop chance.</html>",
-		position = 500,
+		position = 5,
 		closedByDefault = true
 	)
 	String SECTION_POINTS_TRACKER = "sectionPointsTracker";
 
 	@ConfigSection(
-		name = "Burial Tomb",
-		description = "Configuration for the burial tomb.",
-		position = 600,
-		closedByDefault = true
-	)
-	String SECTION_BURIAL_TOMB = "sectionBurialTomb";
-
-	@ConfigSection(
 		name = "Time Tracking",
 		description = "Time tracking and splits.",
-		position = 700,
+		position = 6,
 		closedByDefault = true
 	)
 	String SECTION_TIME_TRACKING = "sectionTimeTracking";
@@ -83,7 +83,7 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigSection(
 		name = "Miscellaneous",
 		description = "Miscellaneous configurations.",
-		position = 800,
+		position = 7,
 		closedByDefault = true
 	)
 	String SECTION_MISCELLANEOUS = "sectionMiscellaneous";

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -388,7 +388,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "pointsTrackerOverlayEnable",
 		name = "Enable Overlay",
 		description = "Show points earned within the raid.",
-		position = 501,
+		position = 0,
 		section = SECTION_POINTS_TRACKER
 	)
 	default boolean pointsTrackerOverlayEnable()
@@ -400,7 +400,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "pointsTrackerShowRoomPoints",
 		name = "Separate Room Points",
 		description = "Show points for the current room separate from total points.",
-		position = 502,
+		position = 1,
 		section = SECTION_POINTS_TRACKER
 	)
 	default boolean pointsTrackerShowRoomPoints()
@@ -412,7 +412,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "pointsTrackerShowUniqueChance",
 		name = "Show Unique %",
 		description = "Show unique chance on the overlay.",
-		position = 503,
+		position = 2,
 		section = SECTION_POINTS_TRACKER
 	)
 	default boolean pointsTrackerShowUniqueChance()
@@ -424,7 +424,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "pointsTrackerShowPetChance",
 		name = "Show Pet %",
 		description = "Show pet chance on the overlay.",
-		position = 504,
+		position = 3,
 		section = SECTION_POINTS_TRACKER
 	)
 	default boolean pointsTrackerShowPetChance()
@@ -436,7 +436,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "pointsTrackerPostRaidMessage",
 		name = "Points Total Message",
 		description = "Show the total points in chat after the raid, akin to the Chambers of Xeric.",
-		position = 505,
+		position = 4,
 		section = SECTION_POINTS_TRACKER
 	)
 	default boolean pointsTrackerPostRaidMessage()


### PR DESCRIPTION
Changes:

* Close all ConfigSection's by default
* Reorder ConfigSection's
* Reposition (renumber) ConfigSection's and ConfigItem's

The layout of the config is now:

```
Boss Sections
Path of <> Sections
Burial Tomb
Invocation Sections
Points Tracker Section
Time Tracking Section
Miscellaneous Section
```

Position numbers now start from 0. This decouples the numbering of a ConfigItem from its ConfigSection, this way if a ConfigSection's position needs changed then all of its belonging ConfigItems do not need renumbered as well.