### PR TITLE
drytracker: option to track player's purple only

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/ConfigMigrationService.java
+++ b/src/main/java/com/duckblade/osrs/toa/ConfigMigrationService.java
@@ -5,9 +5,11 @@ import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HET_PICKAXE_MENU_S
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HET_PICKAXE_PREVENT_EXIT;
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HP_ORB_MODE;
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_QUICK_PROCEED_ENABLE_MODE;
+import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_TRACK_PURPLE_DRY_COUNT_MODE;
 import com.duckblade.osrs.toa.features.QuickProceedSwaps;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeMode;
 import com.duckblade.osrs.toa.features.hporbs.HpOrbMode;
+import com.duckblade.osrs.toa.features.tomb.PurpleTrackingMode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
@@ -29,6 +31,7 @@ public class ConfigMigrationService
 		migrateQuickProceedEnable();
 		migrateHideHpOrbs();
 		migratePickaxeReminder();
+		migrateTrackPurpleDryCount();
 	}
 
 	@VisibleForTesting
@@ -64,6 +67,17 @@ public class ConfigMigrationService
 				KEY_HET_PICKAXE_MENU_SWAP, mode.isSwapStatue(),
 				KEY_HET_PICKAXE_PREVENT_EXIT, mode.isSwapExit()
 			)
+		);
+	}
+
+	@VisibleForTesting
+	void migrateTrackPurpleDryCount()
+	{
+		migrate(
+			"trackPurpleDryCount",
+			KEY_TRACK_PURPLE_DRY_COUNT_MODE,
+			Boolean.class,
+			enabled -> enabled ? PurpleTrackingMode.ANY : PurpleTrackingMode.OFF
 		);
 	}
 

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -9,6 +9,7 @@ import com.duckblade.osrs.toa.features.timetracking.SplitsMode;
 import com.duckblade.osrs.toa.features.updatenotifier.UpdateNotifier;
 import com.duckblade.osrs.toa.util.FontStyle;
 import com.duckblade.osrs.toa.util.HighlightMode;
+import com.duckblade.osrs.toa.features.tomb.PurpleTrackingMode;
 import java.awt.Color;
 import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
@@ -650,16 +651,20 @@ public interface TombsOfAmascutConfig extends Config
 		return false;
 	}
 
+	String KEY_TRACK_PURPLE_DRY_COUNT_MODE = "trackPurpleDryCountMode";
+
 	@ConfigItem(
 		name = "Track Purple Dry Count",
-		description = "Show purple dry streak count in chat upon raid completion.",
+		description = "Show purple dry streak count in chat upon raid completion." +
+			"<br>Any Purple = reset count on any purple chest." +
+			"<br>My Purple = reset count on my purple chest only.",
 		position = 10,
-		keyName = "trackPurpleDryCount",
+		keyName = KEY_TRACK_PURPLE_DRY_COUNT_MODE,
 		section = SECTION_BURIAL_TOMB
 	)
-	default boolean trackPurpleDryCount()
+	default PurpleTrackingMode trackPurpleDryCountMode()
 	{
-		return false;
+		return PurpleTrackingMode.OFF;
 	}
 
 	// Invocation Presets

--- a/src/main/java/com/duckblade/osrs/toa/features/tomb/DryStreakTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/tomb/DryStreakTracker.java
@@ -23,6 +23,11 @@ import net.runelite.client.eventbus.Subscribe;
 public class DryStreakTracker implements PluginLifecycleComponent
 {
 	private static final int VARBIT_ID_SARCOPHAGUS = 14373;
+	private static final int VARBIT_VALUE_CHEST_KEY = 2;
+
+	private static final int[] VARBIT_MULTILOC_IDS_CHEST = new int[]{
+		14356, 14357, 14358, 14359, 14360, 14370, 14371, 14372
+	};
 
 	private final EventBus eventBus;
 	private final Client client;
@@ -33,12 +38,15 @@ public class DryStreakTracker implements PluginLifecycleComponent
 
 	private boolean chestOpened;
 	private boolean purple;
+	private boolean purpleIsMine;
+
 	private int previousCount;
 
 	@Override
 	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
 	{
-		return config.trackPurpleDryCount() && (raidState.getCurrentRoom() == RaidRoom.TOMB || raidState.isInLobby());
+		return config.trackPurpleDryCountMode() != PurpleTrackingMode.OFF &&
+			(raidState.getCurrentRoom() == RaidRoom.TOMB || raidState.isInLobby());
 	}
 
 	@Override
@@ -52,9 +60,34 @@ public class DryStreakTracker implements PluginLifecycleComponent
 			clientThread.invokeLater(() ->
 			{
 				chestOpened = false;
-				purple = client.getVarbitValue(VARBIT_ID_SARCOPHAGUS) % 2 != 0;
+				purple = purpleIsMine = client.getVarbitValue(VARBIT_ID_SARCOPHAGUS) % 2 != 0;
+
+				for (final int varbitId : VARBIT_MULTILOC_IDS_CHEST)
+				{
+					if (client.getVarbitValue(varbitId) == VARBIT_VALUE_CHEST_KEY)
+					{
+						purpleIsMine = false;
+						break;
+					}
+				}
+
 				previousCount = config.getPurpleDryStreakCount();
-				config.setPurpleDryStreakCount(purple ? 0 : previousCount + 1);
+
+				final int count;
+
+				switch (config.trackPurpleDryCountMode())
+				{
+					case ANY:
+						count = purple ? 0 : previousCount + 1;
+						break;
+					case MINE:
+						count = purpleIsMine ? 0 : previousCount + 1;
+						break;
+					default:
+						return;
+				}
+
+				config.setPurpleDryStreakCount(count);
 			});
 		}
 	}
@@ -77,15 +110,23 @@ public class DryStreakTracker implements PluginLifecycleComponent
 		{
 			chestOpened = true;
 
+			final String fmt = "<col=800080>Purple</col> Dry Streak%s: <col=ff0000>%d</col>";
 			final String msg;
 
-			if (purple)
+			switch (config.trackPurpleDryCountMode())
 			{
-				msg = String.format("<col=800080>Purple</col> Dry Streak Ended: <col=ff0000>%d</col>", previousCount);
-			}
-			else
-			{
-				msg = String.format("<col=800080>Purple</col> Dry Streak: <col=ff0000>%d</col>", config.getPurpleDryStreakCount());
+				case ANY:
+					msg = String.format(fmt,
+						purple ? " Ended" : "",
+						purple ? previousCount : config.getPurpleDryStreakCount());
+					break;
+				case MINE:
+					msg = String.format(fmt,
+						purpleIsMine ? " Ended" : "",
+						purpleIsMine ? previousCount : config.getPurpleDryStreakCount());
+					break;
+				default:
+					return;
 			}
 
 			chatMessageManager.queue(QueuedMessage.builder()

--- a/src/main/java/com/duckblade/osrs/toa/features/tomb/PurpleTrackingMode.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/tomb/PurpleTrackingMode.java
@@ -1,0 +1,21 @@
+package com.duckblade.osrs.toa.features.tomb;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PurpleTrackingMode
+{
+	OFF("Off"),
+	ANY("Any Purple"),
+	MINE("My Purple");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return this.name;
+	}
+}

--- a/src/test/java/com/duckblade/osrs/toa/ConfigMigrationServiceTest.java
+++ b/src/test/java/com/duckblade/osrs/toa/ConfigMigrationServiceTest.java
@@ -5,9 +5,11 @@ import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HET_PICKAXE_MENU_S
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HET_PICKAXE_PREVENT_EXIT;
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HP_ORB_MODE;
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_QUICK_PROCEED_ENABLE_MODE;
+import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_TRACK_PURPLE_DRY_COUNT_MODE;
 import com.duckblade.osrs.toa.features.QuickProceedSwaps;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeMode;
 import com.duckblade.osrs.toa.features.hporbs.HpOrbMode;
+import com.duckblade.osrs.toa.features.tomb.PurpleTrackingMode;
 import net.runelite.client.config.ConfigManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -152,4 +154,34 @@ class ConfigMigrationServiceTest
 		verifyNoMoreInteractions(configManager);
 	}
 
+	@Test
+	void trackPurpleDryCountFalse()
+	{
+		when(configManager.getConfiguration(CONFIG_GROUP, "trackPurpleDryCount", Boolean.class)).thenReturn(false);
+		configMigrationService.migrateTrackPurpleDryCount();
+
+		verify(configManager).unsetConfiguration(CONFIG_GROUP, "trackPurpleDryCount");
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_TRACK_PURPLE_DRY_COUNT_MODE, PurpleTrackingMode.OFF);
+		verifyNoMoreInteractions(configManager);
+	}
+
+	@Test
+	void trackPurpleDryCountTrue()
+	{
+		when(configManager.getConfiguration(CONFIG_GROUP, "trackPurpleDryCount", Boolean.class)).thenReturn(true);
+		configMigrationService.migrateTrackPurpleDryCount();
+
+		verify(configManager).unsetConfiguration(CONFIG_GROUP, "trackPurpleDryCount");
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_TRACK_PURPLE_DRY_COUNT_MODE, PurpleTrackingMode.ANY);
+		verifyNoMoreInteractions(configManager);
+	}
+
+	@Test
+	void trackPurpleDryCountNull()
+	{
+		when(configManager.getConfiguration(CONFIG_GROUP, "trackPurpleDryCount", Boolean.class)).thenReturn(null);
+		configMigrationService.migrateTrackPurpleDryCount();
+
+		verifyNoMoreInteractions(configManager);
+	}
 }


### PR DESCRIPTION
[Feature requested in RL discord](https://discord.com/channels/301497432909414422/301497432909414422/1251949396145209435)

Needs testing in-game, since I don't have a team.