### PR TITLE
Fixing point calculations

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/features/pointstracker/PointsTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/pointstracker/PointsTracker.java
@@ -309,7 +309,7 @@ public class PointsTracker implements PluginLifecycleComponent
 
 	public int getPersonalTotalPoints()
 	{
-		return this.personalTotalPoints - BASE_POINTS;
+		return this.personalTotalPoints;
 	}
 
 	public double getPersonalPercent()

--- a/src/main/java/com/duckblade/osrs/toa/features/pointstracker/PointsTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/pointstracker/PointsTracker.java
@@ -229,7 +229,7 @@ public class PointsTracker implements PluginLifecycleComponent
 		}
 		else if (e.getMessage().startsWith(DEATH_MESSAGE))
 		{
-			personalTotalPoints -= (int) Math.max(0.2 * personalTotalPoints, 1000);
+			personalTotalPoints -= (int) (0.2 * personalTotalPoints);
 			if (personalTotalPoints < 0)
 			{
 				personalTotalPoints = 0;

--- a/src/main/java/com/duckblade/osrs/toa/features/pointstracker/PointsTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/pointstracker/PointsTracker.java
@@ -309,7 +309,7 @@ public class PointsTracker implements PluginLifecycleComponent
 
 	public int getPersonalTotalPoints()
 	{
-		return this.personalTotalPoints;
+		return this.personalTotalPoints - BASE_POINTS;
 	}
 
 	public double getPersonalPercent()


### PR DESCRIPTION
TOA points calculation is incorrect #96

These are the proposed fixes for the incorrect point calculations.  This will also result in players seeing their starting points.  Note that the wiki has also been updated to show starting points and the purple chance calculations there are being updated per my findings based on the original OSRS blog post https://secure.runescape.com/m=news/tombs-of-amascut-drop-mechanics--osmumtens-fang?oldschool=1
