### PR TITLE
tomb: death check for cursed phalanx detector

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/features/tomb/CursedPhalanxDetector.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/tomb/CursedPhalanxDetector.java
@@ -5,73 +5,107 @@ import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
 import com.duckblade.osrs.toa.util.InventoryUtil;
 import com.duckblade.osrs.toa.util.RaidRoom;
 import com.duckblade.osrs.toa.util.RaidState;
+import com.duckblade.osrs.toa.util.RaidStateTracker;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import lombok.RequiredArgsConstructor;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.Varbits;
+import net.runelite.api.events.GameTick;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 
 @Singleton
-@RequiredArgsConstructor(onConstructor_ = @Inject)
 public class CursedPhalanxDetector implements PluginLifecycleComponent
 {
-	private static final Set<Integer> CURSED_PHALANX_ITEM_IDS = ImmutableSet.of(
-		ItemID.CURSED_PHALANX,
-		ItemID.OSMUMTENS_FANG_OR
-	);
+    private static final Set<Integer> CURSED_PHALANX_ITEM_IDS = ImmutableSet.of(
+            ItemID.CURSED_PHALANX,
+            ItemID.OSMUMTENS_FANG_OR
+    );
+    private boolean isEligibleForKit = true;
+    @Inject
+    private EventBus eventBus;
+    @Inject
+    private Client client;
 
-	private final EventBus eventBus;
-	private final Client client;
+    @Inject
+    private RaidStateTracker raidStateTracker;
 
-	@Override
-	public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
-	{
-		return raidState.getCurrentRoom() == RaidRoom.TOMB && config.cursedPhalanxDetect();
-	}
+    @Override
+    public boolean isEnabled(final TombsOfAmascutConfig config, final RaidState raidState)
+    {
+        return config.cursedPhalanxDetect();
+    }
 
-	@Override
-	public void startUp()
-	{
-		eventBus.register(this);
-	}
+    @Override
+    public void startUp()
+    {
+        eventBus.register(this);
+    }
 
-	@Override
-	public void shutDown()
-	{
-		eventBus.unregister(this);
-	}
+    @Override
+    public void shutDown()
+    {
+        eventBus.unregister(this);
+    }
 
-	@Subscribe
-	private void onMenuOptionClicked(final MenuOptionClicked event)
-	{
-		if (client.getVarbitValue(Varbits.TOA_RAID_LEVEL) < 500)
-		{
-			return;
-		}
+    @Subscribe
+    private void onGameTick(GameTick e)
+    {
+        if (raidStateTracker.getCurrentState().getCurrentRoom() == null) // reset when not in raid
+        {
+            isEligibleForKit = true;
+            return;
+        }
 
-		final MenuEntry menuEntry = event.getMenuEntry();
+        if ( isEligibleForKit && (
+                client.getVarbitValue(Varbits.TOA_MEMBER_0_HEALTH) == 30 ||
+                client.getVarbitValue(Varbits.TOA_MEMBER_1_HEALTH) == 30 ||
+                client.getVarbitValue(Varbits.TOA_MEMBER_2_HEALTH) == 30 ||
+                client.getVarbitValue(Varbits.TOA_MEMBER_3_HEALTH) == 30 ||
+                client.getVarbitValue(Varbits.TOA_MEMBER_4_HEALTH) == 30 ||
+                client.getVarbitValue(Varbits.TOA_MEMBER_5_HEALTH) == 30 ||
+                client.getVarbitValue(Varbits.TOA_MEMBER_6_HEALTH) == 30 ||
+                client.getVarbitValue(Varbits.TOA_MEMBER_7_HEALTH) == 30
+        ))
+        {
+            isEligibleForKit = false;
+        }
 
-		if (!menuEntry.getOption().equals("Open"))
-		{
-			return;
-		}
+    }
 
-		boolean wearingPhalanx = InventoryUtil.containsAny(client.getItemContainer(InventoryID.EQUIPMENT), CURSED_PHALANX_ITEM_IDS);
-		boolean carryingPhalanx = InventoryUtil.containsAny(client.getItemContainer(InventoryID.INVENTORY), CURSED_PHALANX_ITEM_IDS);
+    @Subscribe
+    private void onMenuOptionClicked(final MenuOptionClicked event)
+    {
+        if (raidStateTracker.getCurrentState().getCurrentRoom() != RaidRoom.TOMB)
+        {
+            return;
+        }
+        if (client.getVarbitValue(Varbits.TOA_RAID_LEVEL) < 500)
+        {
+            return;
+        }
 
-		if (wearingPhalanx || carryingPhalanx)
-		{
-			event.consume();
-			client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Remove and/or drop cursed phalanx before doing that.", null);
-		}
-	}
+        final MenuEntry menuEntry = event.getMenuEntry();
+
+        if (!menuEntry.getOption().equals("Open"))
+        {
+            return;
+        }
+
+        boolean wearingPhalanx = InventoryUtil.containsAny(client.getItemContainer(InventoryID.EQUIPMENT), CURSED_PHALANX_ITEM_IDS);
+        boolean carryingPhalanx = InventoryUtil.containsAny(client.getItemContainer(InventoryID.INVENTORY), CURSED_PHALANX_ITEM_IDS);
+
+        if ((wearingPhalanx || carryingPhalanx) && isEligibleForKit)
+        {
+            event.consume();
+            client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Remove and/or drop cursed phalanx before doing that.", null);
+        }
+    }
 }


### PR DESCRIPTION
### Issue:
Currently the "Detect Cursed Phalanx" feature only looks if you already have a cursed phalanx in inventory or a kitted fang. However, if you complete a 500 invocation raid even though you or a raid member had a death, it will still ask you to drop your kit before looting which is slightly annoying when you know it isnt a kit raid.
### Solution:
This fix continuously checks for any player death utilizing the player orbs' varbits during the raid. If there was a single death, it will not ask you to drop your kit before looting a 500 invocation level raid.

