### PR TITLE
Update README badges to api.runelite.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Utilities and information for raiding the Tombs of Amascut.
 
 
-[![Active Installs](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/tombs-of-amascut)](https://runelite.net/plugin-hub/show/tombs-of-amascut)
-[![Plugin Rank](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/rank/plugin/tombs-of-amascut)](https://runelite.net/plugin-hub/show/tombs-of-amascut)
+[![Active Installs](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/tombs-of-amascut)](https://runelite.net/plugin-hub/show/tombs-of-amascut)
+[![Plugin Rank](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/tombs-of-amascut)](https://runelite.net/plugin-hub/show/tombs-of-amascut)
 
 **Note: While Tombs of Amascut is new, Jagex will be quite strict on what is and is not allowed in ToA plugins.**
 Feel free to request new features in the Issues tab (after searching for an existing matching issue),


### PR DESCRIPTION
The website [i.pluginhub.info](https://i.pluginhub.info), which powers your README badges, is going to be shut down at the end of the month (November 1st, 2024) as you can now use RuneLite's API to generate these shields (as was done in this PR).

I highly recommend you merge this PR, or make this change yourself, before the shutdown date to avoid your badges breaking.

You should also create a PR to the hub so that your readme updates on [RuneLite.net's Plugin Hub](https://runelite.net/plugin-hub/show/tombs-of-amascut) website after merging this PR, but that's up to you

Anyway, thanks for using my website while it was alive :heart: