### PR TITLE
Tile number in Scarab matching puzzle

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/ConfigMigrationService.java
+++ b/src/main/java/com/duckblade/osrs/toa/ConfigMigrationService.java
@@ -5,9 +5,12 @@ import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HET_PICKAXE_MENU_S
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HET_PICKAXE_PREVENT_EXIT;
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HP_ORB_MODE;
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_QUICK_PROCEED_ENABLE_MODE;
+import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_SCABARAS_MATCHING_DISPLAY_MODE_NAME;
+import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_SCABARAS_MATCHING_DISPLAY_MODE_TILE;
 import com.duckblade.osrs.toa.features.QuickProceedSwaps;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeMode;
 import com.duckblade.osrs.toa.features.hporbs.HpOrbMode;
+import com.duckblade.osrs.toa.features.scabaras.overlay.MatchingTileDisplayMode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
@@ -29,6 +32,7 @@ public class ConfigMigrationService
 		migrateQuickProceedEnable();
 		migrateHideHpOrbs();
 		migratePickaxeReminder();
+		migrateScabarasMatchingDisplayMode();
 	}
 
 	@VisibleForTesting
@@ -63,6 +67,20 @@ public class ConfigMigrationService
 			mode -> ImmutableMap.of(
 				KEY_HET_PICKAXE_MENU_SWAP, mode.isSwapStatue(),
 				KEY_HET_PICKAXE_PREVENT_EXIT, mode.isSwapExit()
+			)
+		);
+	}
+
+	@SuppressWarnings("deprecation")
+	@VisibleForTesting
+	void migrateScabarasMatchingDisplayMode()
+	{
+		migrateMany(
+			"scabarasMatchingDisplayMode",
+			MatchingTileDisplayMode.class,
+			mode -> ImmutableMap.of(
+				KEY_SCABARAS_MATCHING_DISPLAY_MODE_TILE, mode == MatchingTileDisplayMode.TILE || mode == MatchingTileDisplayMode.BOTH,
+				KEY_SCABARAS_MATCHING_DISPLAY_MODE_NAME, mode == MatchingTileDisplayMode.NAME || mode == MatchingTileDisplayMode.BOTH
 			)
 		);
 	}

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -565,13 +565,13 @@ public interface TombsOfAmascutConfig extends Config
 	@ConfigItem(
 		keyName = "scabarasMatchingDisplayMode",
 		name = "Matching Display",
-		description = "Whether to show highlight tiles, show names of tiles, or both for the matching puzzle.",
+		description = "Whether to show highlight tiles, show names of tiles, show numbering of tiles, or a mix of these in the matching puzzle.",
 		position = 7,
 		section = SECTION_SCABARAS
 	)
 	default MatchingTileDisplayMode scabarasMatchingDisplayMode()
 	{
-		return MatchingTileDisplayMode.BOTH;
+		return MatchingTileDisplayMode.TILE_AND_NAME;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -6,7 +6,6 @@ import com.duckblade.osrs.toa.features.boss.kephri.swarmer.SwarmerPanelManager;
 import com.duckblade.osrs.toa.features.hporbs.HpOrbMode;
 import com.duckblade.osrs.toa.features.scabaras.ScabarasHelperMode;
 import com.duckblade.osrs.toa.features.scabaras.SkipObeliskOverlay;
-import com.duckblade.osrs.toa.features.scabaras.overlay.MatchingTileDisplayMode;
 import com.duckblade.osrs.toa.features.timetracking.SplitsMode;
 import com.duckblade.osrs.toa.features.updatenotifier.UpdateNotifier;
 import com.duckblade.osrs.toa.util.FontStyle;
@@ -171,11 +170,11 @@ public interface TombsOfAmascutConfig extends Config
 	}
 
 	@ConfigItem(
-			name = "Font Type",
-			description = "Type of font",
-			position = 1,
-			keyName = "fontType",
-			section = SECTION_KEPHRI
+		name = "Font Type",
+		description = "Type of font",
+		position = 1,
+		keyName = "fontType",
+		section = SECTION_KEPHRI
 	)
 	default SwarmerFonts swarmerFontType()
 	{
@@ -183,11 +182,11 @@ public interface TombsOfAmascutConfig extends Config
 	}
 
 	@ConfigItem(
-			name = "Use Bold Font",
-			description = "Font style of swarm overlay.",
-			position = 2,
-			keyName = "useBoldFont",
-			section = SECTION_KEPHRI
+		name = "Use Bold Font",
+		description = "Font style of swarm overlay.",
+		position = 2,
+		keyName = "useBoldFont",
+		section = SECTION_KEPHRI
 	)
 	default boolean useBoldFont()
 	{
@@ -195,11 +194,11 @@ public interface TombsOfAmascutConfig extends Config
 	}
 
 	@ConfigItem(
-			name = "Font Size",
-			description = "Font size of swarm overlay.",
-			position = 3,
-			keyName = "swarmerFontSize",
-			section = SECTION_KEPHRI
+		name = "Font Size",
+		description = "Font size of swarm overlay.",
+		position = 3,
+		keyName = "swarmerFontSize",
+		section = SECTION_KEPHRI
 	)
 	@Units(Units.PIXELS)
 	@Range(min = 12)
@@ -209,11 +208,11 @@ public interface TombsOfAmascutConfig extends Config
 	}
 
 	@ConfigItem(
-			name = "Side Panel",
-			description = "Show a side panel with summary data for previous raids.",
-			position = 4,
-			keyName = "swarmerSidePanel",
-			section = SECTION_KEPHRI
+		name = "Side Panel",
+		description = "Show a side panel with summary data for previous raids.",
+		position = 4,
+		keyName = "swarmerSidePanel",
+		section = SECTION_KEPHRI
 	)
 	default SwarmerPanelManager.PanelMode swarmerSidePanel()
 	{
@@ -221,11 +220,11 @@ public interface TombsOfAmascutConfig extends Config
 	}
 
 	@ConfigItem(
-			name = "Font Color",
-			description = "Font color of swarm overlay.",
-			position = 4,
-			keyName = "swarmerFontColor",
-			section = SECTION_KEPHRI
+		name = "Font Color",
+		description = "Font color of swarm overlay.",
+		position = 4,
+		keyName = "swarmerFontColor",
+		section = SECTION_KEPHRI
 	)
 	default Color swarmerFontColor()
 	{
@@ -562,16 +561,44 @@ public interface TombsOfAmascutConfig extends Config
 		return Color.blue;
 	}
 
+	String KEY_SCABARAS_MATCHING_DISPLAY_MODE_TILE = "scabarasMatchingDisplayModeTile";
+
 	@ConfigItem(
-		keyName = "scabarasMatchingDisplayMode",
-		name = "Matching Display",
-		description = "Whether to show highlight tiles, show names of tiles, show numbering of tiles, or a mix of these in the matching puzzle.",
+		keyName = KEY_SCABARAS_MATCHING_DISPLAY_MODE_TILE,
+		name = "Matching Display - Tile",
+		description = "Whether to highlight tiles in the matching puzzle.",
 		position = 7,
 		section = SECTION_SCABARAS
 	)
-	default MatchingTileDisplayMode scabarasMatchingDisplayMode()
+	default boolean scabarasMatchingDisplayModeTile()
 	{
-		return MatchingTileDisplayMode.TILE_AND_NAME;
+		return true;
+	}
+
+	String KEY_SCABARAS_MATCHING_DISPLAY_MODE_NAME = "scabarasMatchingDisplayModeName";
+
+	@ConfigItem(
+		keyName = KEY_SCABARAS_MATCHING_DISPLAY_MODE_NAME,
+		name = "Matching Display - Name",
+		description = "Whether to show the tile name in the matching puzzle.",
+		position = 8,
+		section = SECTION_SCABARAS
+	)
+	default boolean scabarasMatchingDisplayModeName()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "scabarasMatchingDisplayModeNumber",
+		name = "Matching Display - Number",
+		description = "Whether to show the tile number in the matching puzzle.",
+		position = 9,
+		section = SECTION_SCABARAS
+	)
+	default boolean scabarasMatchingDisplayModeNumber()
+	{
+		return false;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingPuzzleSolver.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingPuzzleSolver.java
@@ -49,6 +49,17 @@ public class MatchingPuzzleSolver implements PluginLifecycleComponent
 		.put(45373, Color.green) // boot
 		.build();
 
+	private static final Map<Integer, Integer> TILE_NUMBER = ImmutableMap.<Integer, Integer>builder().put(45365, 1) // line
+		.put(45366, 2) // knives
+		.put(45367, 3) // crook
+		.put(45368, 4) // diamond
+		.put(45369, 5) // hand
+		.put(45370, 6) // star
+		.put(45371, 7) // bird
+		.put(45372, 8) // wiggle
+		.put(45373, 9) // boot
+		.build();
+
 	private static final Map<Integer, Integer> MATCHED_OBJECT_IDS = ImmutableMap.<Integer, Integer>builder().put(45388, 45365) // line
 		.put(45389, 45366) // knives
 		.put(45386, 45367) // crook
@@ -91,7 +102,7 @@ public class MatchingPuzzleSolver implements PluginLifecycleComponent
 		if (TILE_COLORS.containsKey(id))
 		{
 			LocalPoint lp = e.getGroundObject().getLocalLocation();
-			discoveredTiles.put(lp, new MatchingTile(lp, TILE_NAMES.getOrDefault(id, "Unknown"), TILE_COLORS.getOrDefault(id, Color.black)));
+			discoveredTiles.put(lp, new MatchingTile(lp, TILE_NAMES.getOrDefault(id, "Unknown"), TILE_COLORS.getOrDefault(id, Color.black), TILE_NUMBER.getOrDefault(id, 0)));
 		}
 	}
 

--- a/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingPuzzleSolver.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingPuzzleSolver.java
@@ -27,7 +27,8 @@ import net.runelite.client.eventbus.Subscribe;
 public class MatchingPuzzleSolver implements PluginLifecycleComponent
 {
 
-	private static final Map<Integer, String> TILE_NAMES = ImmutableMap.<Integer, String>builder().put(45365, "Line") // line
+	private static final Map<Integer, String> TILE_NAMES = ImmutableMap.<Integer, String>builder()
+		.put(45365, "Line") // line
 		.put(45366, "Knives") // knives
 		.put(45367, "Crook") // crook
 		.put(45368, "Diamond") // diamond
@@ -38,7 +39,8 @@ public class MatchingPuzzleSolver implements PluginLifecycleComponent
 		.put(45373, "Boot") // boot
 		.build();
 
-	private static final Map<Integer, Color> TILE_COLORS = ImmutableMap.<Integer, Color>builder().put(45365, Color.black) // line
+	private static final Map<Integer, Color> TILE_COLORS = ImmutableMap.<Integer, Color>builder()
+		.put(45365, Color.black) // line
 		.put(45366, Color.red) // knives
 		.put(45367, Color.magenta) // crook
 		.put(45368, Color.blue) // diamond
@@ -49,13 +51,15 @@ public class MatchingPuzzleSolver implements PluginLifecycleComponent
 		.put(45373, Color.green) // boot
 		.build();
 
-	private static final Map<Integer, Integer> TILE_NUMBER = ImmutableMap.<Integer, Integer>builder().put(45365, 1) // line
-		.put(45366, 2) // knives
-		.put(45367, 3) // crook
-		.put(45368, 4) // diamond
-		.put(45369, 5) // hand
-		.put(45370, 6) // star
-		.put(45371, 7) // bird
+	private static final Map<Integer, Integer> TILE_NUMBER = ImmutableMap.<Integer, Integer>builder()
+		// these are intentionally out of id order since line, crook, hand, bird are always auto-completed in solos
+		.put(45365, 1) // line
+		.put(45367, 2) // crook
+		.put(45369, 3) // hand
+		.put(45371, 4) // bird
+		.put(45366, 5) // knives
+		.put(45368, 6) // diamond
+		.put(45370, 7) // star
 		.put(45372, 8) // wiggle
 		.put(45373, 9) // boot
 		.build();

--- a/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingTile.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingTile.java
@@ -11,7 +11,7 @@ public class MatchingTile
 	private final LocalPoint localPoint;
 	private final String name;
 	private final Color color;
-	private final Integer number;
+	private final int number;
 	private boolean matched;
 
 }

--- a/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingTile.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingTile.java
@@ -11,6 +11,7 @@ public class MatchingTile
 	private final LocalPoint localPoint;
 	private final String name;
 	private final Color color;
+	private final Integer number;
 	private boolean matched;
 
 }

--- a/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingTileDisplayMode.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingTileDisplayMode.java
@@ -6,7 +6,9 @@ public enum MatchingTileDisplayMode
 	DISABLED,
 	TILE,
 	NAME,
-	BOTH,
+	NUMBER,
+	TILE_AND_NAME,
+	TILE_AND_NUMBER,
 	;
 
 }

--- a/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingTileDisplayMode.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/MatchingTileDisplayMode.java
@@ -1,14 +1,16 @@
 package com.duckblade.osrs.toa.features.scabaras.overlay;
 
+/**
+ * @deprecated Replaced by multiple booleans in the config.
+ */
+@Deprecated
 public enum MatchingTileDisplayMode
 {
 
 	DISABLED,
 	TILE,
 	NAME,
-	NUMBER,
-	TILE_AND_NAME,
-	TILE_AND_NUMBER,
+	BOTH,
 	;
 
 }

--- a/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/ScabarasOverlay.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/ScabarasOverlay.java
@@ -120,8 +120,9 @@ public class ScabarasOverlay extends Overlay
 		}
 
 		int matchedOpacity = config.scabarasMatchingCompletedOpacity();
-		boolean tile = mode == MatchingTileDisplayMode.TILE || mode == MatchingTileDisplayMode.BOTH;
-		boolean name = mode == MatchingTileDisplayMode.NAME || mode == MatchingTileDisplayMode.BOTH;
+		boolean tile = mode == MatchingTileDisplayMode.TILE || mode == MatchingTileDisplayMode.TILE_AND_NAME || mode == MatchingTileDisplayMode.TILE_AND_NUMBER;
+		boolean name = mode == MatchingTileDisplayMode.NAME || mode == MatchingTileDisplayMode.TILE_AND_NAME;
+		boolean number = mode == MatchingTileDisplayMode.NUMBER || mode == MatchingTileDisplayMode.TILE_AND_NUMBER;
 		matchingTiles.values().forEach(mt ->
 		{
 			Polygon canvasTilePoly = Perspective.getCanvasTilePoly(client, mt.getLocalPoint());
@@ -140,11 +141,15 @@ public class ScabarasOverlay extends Overlay
 			{
 				OverlayUtil.renderPolygon(graphics, canvasTilePoly, color, new Color(0, 0, 0, Math.min(color.getAlpha(), 50)), new BasicStroke(2));
 			}
+
+			Rectangle tileB = canvasTilePoly.getBounds();
+			Rectangle txtB = graphics.getFontMetrics().getStringBounds(mt.getName(), graphics).getBounds();
+			Point p = new Point(tileB.x + tileB.width / 2 - txtB.width / 2, tileB.y + tileB.height / 2 + txtB.height / 2);
+			if (number) {
+				renderTextLocationAlpha(graphics, p, String.valueOf(mt.getNumber()), color);
+			}
 			if (name)
 			{
-				Rectangle tileB = canvasTilePoly.getBounds();
-				Rectangle txtB = graphics.getFontMetrics().getStringBounds(mt.getName(), graphics).getBounds();
-				Point p = new Point(tileB.x + tileB.width / 2 - txtB.width / 2, tileB.y + tileB.height / 2 + txtB.height / 2);
 				renderTextLocationAlpha(graphics, p, mt.getName(), color);
 			}
 		});

--- a/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/ScabarasOverlay.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/scabaras/overlay/ScabarasOverlay.java
@@ -113,16 +113,15 @@ public class ScabarasOverlay extends Overlay
 
 	private void renderLocalMatching(Graphics2D graphics, Map<LocalPoint, MatchingTile> matchingTiles)
 	{
-		MatchingTileDisplayMode mode = config.scabarasMatchingDisplayMode();
-		if (mode == MatchingTileDisplayMode.DISABLED)
+		boolean tile = config.scabarasMatchingDisplayModeTile();
+		boolean name = config.scabarasMatchingDisplayModeName();
+		boolean number = config.scabarasMatchingDisplayModeNumber();
+		if (!tile && !name && !number)
 		{
 			return;
 		}
 
 		int matchedOpacity = config.scabarasMatchingCompletedOpacity();
-		boolean tile = mode == MatchingTileDisplayMode.TILE || mode == MatchingTileDisplayMode.TILE_AND_NAME || mode == MatchingTileDisplayMode.TILE_AND_NUMBER;
-		boolean name = mode == MatchingTileDisplayMode.NAME || mode == MatchingTileDisplayMode.TILE_AND_NAME;
-		boolean number = mode == MatchingTileDisplayMode.NUMBER || mode == MatchingTileDisplayMode.TILE_AND_NUMBER;
 		matchingTiles.values().forEach(mt ->
 		{
 			Polygon canvasTilePoly = Perspective.getCanvasTilePoly(client, mt.getLocalPoint());
@@ -142,16 +141,29 @@ public class ScabarasOverlay extends Overlay
 				OverlayUtil.renderPolygon(graphics, canvasTilePoly, color, new Color(0, 0, 0, Math.min(color.getAlpha(), 50)), new BasicStroke(2));
 			}
 
-			Rectangle tileB = canvasTilePoly.getBounds();
-			Rectangle txtB = graphics.getFontMetrics().getStringBounds(mt.getName(), graphics).getBounds();
-			Point p = new Point(tileB.x + tileB.width / 2 - txtB.width / 2, tileB.y + tileB.height / 2 + txtB.height / 2);
-			if (number) {
-				renderTextLocationAlpha(graphics, p, String.valueOf(mt.getNumber()), color);
-			}
-			if (name)
+			if (!name && !number)
 			{
-				renderTextLocationAlpha(graphics, p, mt.getName(), color);
+				return;
 			}
+
+			String text;
+			if (name && number)
+			{
+				text = mt.getNumber() + " - " + mt.getName();
+			}
+			else if (name)
+			{
+				text = mt.getName();
+			}
+			else
+			{
+				text = String.valueOf(mt.getNumber());
+			}
+
+			Rectangle tileB = canvasTilePoly.getBounds();
+			Rectangle txtB = graphics.getFontMetrics().getStringBounds(text, graphics).getBounds();
+			Point p = new Point(tileB.x + tileB.width / 2 - txtB.width / 2, tileB.y + tileB.height / 2 + txtB.height / 2);
+			renderTextLocationAlpha(graphics, p, text, color);
 		});
 	}
 

--- a/src/test/java/com/duckblade/osrs/toa/ConfigMigrationServiceTest.java
+++ b/src/test/java/com/duckblade/osrs/toa/ConfigMigrationServiceTest.java
@@ -5,9 +5,12 @@ import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HET_PICKAXE_MENU_S
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HET_PICKAXE_PREVENT_EXIT;
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_HP_ORB_MODE;
 import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_QUICK_PROCEED_ENABLE_MODE;
+import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_SCABARAS_MATCHING_DISPLAY_MODE_NAME;
+import static com.duckblade.osrs.toa.TombsOfAmascutConfig.KEY_SCABARAS_MATCHING_DISPLAY_MODE_TILE;
 import com.duckblade.osrs.toa.features.QuickProceedSwaps;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeMode;
 import com.duckblade.osrs.toa.features.hporbs.HpOrbMode;
+import com.duckblade.osrs.toa.features.scabaras.overlay.MatchingTileDisplayMode;
 import net.runelite.client.config.ConfigManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -120,7 +123,11 @@ class ConfigMigrationServiceTest
 	@Test
 	void pickaxeReminderPreventExit()
 	{
-		when(configManager.getConfiguration(CONFIG_GROUP, "depositPickaxeMode", DepositPickaxeMode.class)).thenReturn(DepositPickaxeMode.PREVENT_EXIT);
+		when(configManager.getConfiguration(
+			CONFIG_GROUP,
+			"depositPickaxeMode",
+			DepositPickaxeMode.class
+		)).thenReturn(DepositPickaxeMode.PREVENT_EXIT);
 		configMigrationService.migratePickaxeReminder();
 
 		verify(configManager).unsetConfiguration(CONFIG_GROUP, "depositPickaxeMode");
@@ -148,6 +155,73 @@ class ConfigMigrationServiceTest
 	{
 		when(configManager.getConfiguration(CONFIG_GROUP, "depositPickaxeMode", DepositPickaxeMode.class)).thenReturn(null);
 		configMigrationService.migratePickaxeReminder();
+
+		verifyNoMoreInteractions(configManager);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	void scabarasMatchingDisplayModeDisabled()
+	{
+		when(configManager.getConfiguration(CONFIG_GROUP, "scabarasMatchingDisplayMode", MatchingTileDisplayMode.class))
+			.thenReturn(MatchingTileDisplayMode.DISABLED);
+		configMigrationService.migrateScabarasMatchingDisplayMode();
+
+		verify(configManager).unsetConfiguration(CONFIG_GROUP, "scabarasMatchingDisplayMode");
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_SCABARAS_MATCHING_DISPLAY_MODE_TILE, false);
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_SCABARAS_MATCHING_DISPLAY_MODE_NAME, false);
+		verifyNoMoreInteractions(configManager);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	void scabarasMatchingDisplayModeTile()
+	{
+		when(configManager.getConfiguration(CONFIG_GROUP, "scabarasMatchingDisplayMode", MatchingTileDisplayMode.class))
+			.thenReturn(MatchingTileDisplayMode.TILE);
+		configMigrationService.migrateScabarasMatchingDisplayMode();
+
+		verify(configManager).unsetConfiguration(CONFIG_GROUP, "scabarasMatchingDisplayMode");
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_SCABARAS_MATCHING_DISPLAY_MODE_TILE, true);
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_SCABARAS_MATCHING_DISPLAY_MODE_NAME, false);
+		verifyNoMoreInteractions(configManager);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	void scabarasMatchingDisplayModeName()
+	{
+		when(configManager.getConfiguration(CONFIG_GROUP, "scabarasMatchingDisplayMode", MatchingTileDisplayMode.class))
+			.thenReturn(MatchingTileDisplayMode.NAME);
+		configMigrationService.migrateScabarasMatchingDisplayMode();
+
+		verify(configManager).unsetConfiguration(CONFIG_GROUP, "scabarasMatchingDisplayMode");
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_SCABARAS_MATCHING_DISPLAY_MODE_TILE, false);
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_SCABARAS_MATCHING_DISPLAY_MODE_NAME, true);
+		verifyNoMoreInteractions(configManager);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	void scabarasMatchingDisplayModeBoth()
+	{
+		when(configManager.getConfiguration(CONFIG_GROUP, "scabarasMatchingDisplayMode", MatchingTileDisplayMode.class))
+			.thenReturn(MatchingTileDisplayMode.BOTH);
+		configMigrationService.migrateScabarasMatchingDisplayMode();
+
+		verify(configManager).unsetConfiguration(CONFIG_GROUP, "scabarasMatchingDisplayMode");
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_SCABARAS_MATCHING_DISPLAY_MODE_TILE, true);
+		verify(configManager).setConfiguration(CONFIG_GROUP, KEY_SCABARAS_MATCHING_DISPLAY_MODE_NAME, true);
+		verifyNoMoreInteractions(configManager);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	void scabarasMatchingDisplayModeNull()
+	{
+		when(configManager.getConfiguration(CONFIG_GROUP, "scabarasMatchingDisplayMode", MatchingTileDisplayMode.class))
+			.thenReturn(null);
+		configMigrationService.migrateScabarasMatchingDisplayMode();
 
 		verifyNoMoreInteractions(configManager);
 	}


### PR DESCRIPTION
In the Scarab matching puzzle, add the possibility to display a number instead of only the name. In this case, the team of players do not have to memorize the ordering of colors or names, but can go by the numbers.
