### PR TITLE
depositbox: case-insensitive matching

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -1068,15 +1068,28 @@ public interface TombsOfAmascutConfig extends Config
 
 	// Deposit box
 
-	String KEY_DEPOSIT_BOX_FILTER_STRING = "depositBoxFilterString";
+	String KEY_DEPOSIT_BOX_FILTER_STRING_FIRST = "depositBoxFilterStringFirstPass";
 	@ConfigItem(
-		keyName = KEY_DEPOSIT_BOX_FILTER_STRING,
-		name = "Allowed Items",
-		description = "Comma-separated item names which should be allowed for depositing. Does not support wildcards.",
+		keyName = KEY_DEPOSIT_BOX_FILTER_STRING_FIRST,
+		name = "Allowed Items - First Deposit",
+		description = "Comma-separated item names which should be allowed for depositing after defeating 2 path bosses (first set of supplies). Does not support wildcards.",
 		position = 1,
 		section = SECTION_DEPOSIT_BOX
 	)
-	default String depositBoxFilterString()
+	default String depositBoxFilterStringFirstPass()
+	{
+		return "Divine super combat potion(4),Divine super combat potion(3),Divine super combat potion(2),Divine super combat potion(1)";
+	}
+
+	String KEY_DEPOSIT_BOX_FILTER_STRING_SECOND = "depositBoxFilterStringSecondPass";
+	@ConfigItem(
+		keyName = KEY_DEPOSIT_BOX_FILTER_STRING_SECOND,
+		name = "Allowed Items - Second Deposit",
+		description = "Comma-separated item names which should be allowed for depositing after defeating all 4 path bosses (second set of supplies). Does not support wildcards.",
+		position = 2,
+		section = SECTION_DEPOSIT_BOX
+	)
+	default String depositBoxFilterStringSecondPass()
 	{
 		return "Divine super combat potion(4),Divine super combat potion(3),Divine super combat potion(2),Divine super combat potion(1)";
 	}
@@ -1085,7 +1098,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "depositBoxPreventUse",
 		name = "Prevent Deposit on Use",
 		description = "Restricts depositing items by using them on the deposit box to those specified in 'Allowed Items'.",
-		position = 2,
+		position = 3,
 		section = SECTION_DEPOSIT_BOX
 	)
 	default boolean depositBoxPreventUse()
@@ -1097,7 +1110,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "depositBoxPreventInterface",
 		name = "Prevent Deposit in Interface",
 		description = "Restricts depositing items from within the deposit box UI to those specified in 'Allowed Items'.<br>This can be overridden using right-click.",
-		position = 3,
+		position = 4,
 		section = SECTION_DEPOSIT_BOX
 	)
 	default boolean depositBoxPreventInterface()
@@ -1109,7 +1122,7 @@ public interface TombsOfAmascutConfig extends Config
 		keyName = "depositBoxInterfaceOverlay",
 		name = "Highlight Items in Interface",
 		description = "Adds an overlay showing the allowed/disallowed items in the deposit box UI.",
-		position = 4,
+		position = 5,
 		section = SECTION_DEPOSIT_BOX
 	)
 	default boolean depositBoxInterfaceOverlay()

--- a/src/main/java/com/duckblade/osrs/toa/features/DepositBoxFilter.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/DepositBoxFilter.java
@@ -6,8 +6,8 @@ import com.duckblade.osrs.toa.util.RaidRoom;
 import com.duckblade.osrs.toa.util.RaidState;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.RequiredArgsConstructor;
@@ -61,9 +61,12 @@ public class DepositBoxFilter implements PluginLifecycleComponent
 	@Override
 	public boolean isEnabled(TombsOfAmascutConfig config, RaidState currentState)
 	{
-		if (currentState.getCurrentRoom() == RaidRoom.NEXUS) // todo
+		if (currentState.getCurrentRoom() == RaidRoom.NEXUS)
 		{
-			this.allowedItemNames = new HashSet<>(Text.fromCSV(config.depositBoxFilterString()));
+			this.allowedItemNames = Text.fromCSV(config.depositBoxFilterString())
+				.stream()
+				.map(String::toLowerCase)
+				.collect(Collectors.toSet());
 			this.preventInterfaceDeposit = config.depositBoxPreventInterface();
 			this.preventUseDeposit = config.depositBoxPreventUse();
 			return true;
@@ -93,7 +96,7 @@ public class DepositBoxFilter implements PluginLifecycleComponent
 
 	boolean isDepositAllowed(String itemName)
 	{
-		return allowedItemNames.contains(Text.removeTags(itemName));
+		return allowedItemNames.contains(Text.removeTags(itemName).toLowerCase());
 	}
 
 	private void interceptDepositAction(MenuEntryAdded e)

--- a/src/main/java/com/duckblade/osrs/toa/features/pointstracker/PointsTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/pointstracker/PointsTracker.java
@@ -321,7 +321,11 @@ public class PointsTracker implements PluginLifecycleComponent
 
 	public int getPersonalTotalPoints()
 	{
-		return this.personalTotalPoints - BASE_POINTS;
+		if (!partyPointsTracker.isInParty())
+		{
+			return this.personalTotalPoints - BASE_POINTS + nonPartyPoints;
+		}
+		return this.personalTotalPoints;
 	}
 
 	public double getPersonalPercent()
@@ -340,7 +344,7 @@ public class PointsTracker implements PluginLifecycleComponent
 		{
 			return partyPointsTracker.getTotalPartyPoints();
 		}
-		return getPersonalTotalPoints() + nonPartyPoints;
+		return getPersonalTotalPoints();
 	}
 
 	public double getUniqueChance()

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -50,6 +50,7 @@ import com.duckblade.osrs.toa.features.tomb.DryStreakTracker;
 import com.duckblade.osrs.toa.features.tomb.SarcophagusOpeningSoundPlayer;
 import com.duckblade.osrs.toa.features.tomb.SarcophagusRecolorer;
 import com.duckblade.osrs.toa.features.updatenotifier.UpdateNotifier;
+import com.duckblade.osrs.toa.util.RaidCompletionTracker;
 import com.duckblade.osrs.toa.util.RaidStateTracker;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -101,6 +102,7 @@ public class TombsOfAmascutModule extends AbstractModule
 		lifecycleComponents.addBinding().to(PurpleWeightingManager.class);
 		lifecycleComponents.addBinding().to(PurpleWeightingPartyBoardManager.class);
 		lifecycleComponents.addBinding().to(QuickProceedSwaps.class);
+		lifecycleComponents.addBinding().to(RaidCompletionTracker.class);
 		lifecycleComponents.addBinding().to(RaidStateTracker.class);
 		lifecycleComponents.addBinding().to(SarcophagusOpeningSoundPlayer.class);
 		lifecycleComponents.addBinding().to(SarcophagusRecolorer.class);

--- a/src/main/java/com/duckblade/osrs/toa/util/RaidCompletionTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/util/RaidCompletionTracker.java
@@ -1,0 +1,69 @@
+package com.duckblade.osrs.toa.util;
+
+import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class RaidCompletionTracker implements PluginLifecycleComponent
+{
+
+	private final EventBus eventBus;
+
+	private final Set<String> completedBosses = new HashSet<>();
+
+	@Override
+	public void startUp()
+	{
+		eventBus.register(this);
+	}
+
+	@Override
+	public void shutDown()
+	{
+		eventBus.unregister(this);
+	}
+
+	@Subscribe(priority = Float.MAX_VALUE)
+	public void onChatMessage(ChatMessage e)
+	{
+		if (e.getType() != ChatMessageType.GAMEMESSAGE)
+		{
+			return;
+		}
+
+		if (e.getMessage().startsWith("Challenge complete: "))
+		{
+			String bossName = e.getMessage()
+				.substring("Challenge complete: ".length(), e.getMessage().indexOf('.'));
+			completedBosses.add(bossName);
+		}
+	}
+
+	@Subscribe
+	public void onRaidStateChanged(RaidStateChanged e)
+	{
+		if (!e.getNewState().isInRaid())
+		{
+			completedBosses.clear();
+		}
+	}
+
+	public Set<String> getCompletedBosses()
+	{
+		return Collections.unmodifiableSet(completedBosses);
+	}
+
+}

--- a/src/main/java/com/duckblade/osrs/toa/util/RaidStateTracker.java
+++ b/src/main/java/com/duckblade/osrs/toa/util/RaidStateTracker.java
@@ -6,11 +6,11 @@ import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.runelite.api.Client;
-import net.runelite.api.Varbits;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
@@ -96,12 +96,12 @@ public class RaidStateTracker implements PluginLifecycleComponent
 	private int countPlayers()
 	{
 		return 1 +
-			(client.getVarbitValue(Varbits.TOA_MEMBER_1_HEALTH) != 0 ? 1 : 0) +
-			(client.getVarbitValue(Varbits.TOA_MEMBER_2_HEALTH) != 0 ? 1 : 0) +
-			(client.getVarbitValue(Varbits.TOA_MEMBER_3_HEALTH) != 0 ? 1 : 0) +
-			(client.getVarbitValue(Varbits.TOA_MEMBER_4_HEALTH) != 0 ? 1 : 0) +
-			(client.getVarbitValue(Varbits.TOA_MEMBER_5_HEALTH) != 0 ? 1 : 0) +
-			(client.getVarbitValue(Varbits.TOA_MEMBER_6_HEALTH) != 0 ? 1 : 0) +
-			(client.getVarbitValue(Varbits.TOA_MEMBER_7_HEALTH) != 0 ? 1 : 0);
+			(client.getVarbitValue(VarbitID.TOA_CLIENT_P1) != 0 ? 1 : 0) +
+			(client.getVarbitValue(VarbitID.TOA_CLIENT_P2) != 0 ? 1 : 0) +
+			(client.getVarbitValue(VarbitID.TOA_CLIENT_P3) != 0 ? 1 : 0) +
+			(client.getVarbitValue(VarbitID.TOA_CLIENT_P4) != 0 ? 1 : 0) +
+			(client.getVarbitValue(VarbitID.TOA_CLIENT_P5) != 0 ? 1 : 0) +
+			(client.getVarbitValue(VarbitID.TOA_CLIENT_P6) != 0 ? 1 : 0) +
+			(client.getVarbitValue(VarbitID.TOA_CLIENT_P7) != 0 ? 1 : 0);
 	}
 }

--- a/src/test/java/com/duckblade/osrs/toa/launcher/TombsOfAmascutPluginTest.java
+++ b/src/test/java/com/duckblade/osrs/toa/launcher/TombsOfAmascutPluginTest.java
@@ -1,7 +1,7 @@
-package launcher;
+package com.duckblade.osrs.toa.launcher;
 
 import com.duckblade.osrs.toa.TombsOfAmascutPlugin;
-import launcher.debugplugins.ToaDebugPlugin;
+import com.duckblade.osrs.toa.launcher.debugplugins.ToaDebugPlugin;
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 

--- a/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/AkkhaShadowOverridesOverlay.java
+++ b/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/AkkhaShadowOverridesOverlay.java
@@ -1,4 +1,4 @@
-package launcher.debugplugins;
+package com.duckblade.osrs.toa.launcher.debugplugins;
 
 import com.duckblade.osrs.toa.util.FontStyle;
 import com.duckblade.osrs.toa.util.OverlayUtil;
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Model;
 import net.runelite.api.NPC;
@@ -26,10 +27,17 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 public class AkkhaShadowOverridesOverlay extends Overlay
 {
 
+	private final ToaDebugConfig config;
+
 	private final Set<NPC> shadows = new TreeSet<>(Comparator.comparing(NPC::getIndex));
 
-	public AkkhaShadowOverridesOverlay()
+	@Inject
+	public AkkhaShadowOverridesOverlay(
+		ToaDebugConfig config
+	)
 	{
+		this.config = config;
+
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
@@ -55,6 +63,11 @@ public class AkkhaShadowOverridesOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (!config.akkhaShadowHsl())
+		{
+			return null;
+		}
+
 		shadows.forEach((npc) ->
 		{
 			{

--- a/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/HetSolverDebugOverlay.java
+++ b/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/HetSolverDebugOverlay.java
@@ -1,4 +1,4 @@
-package launcher.debugplugins;
+package com.duckblade.osrs.toa.launcher.debugplugins;
 
 import com.duckblade.osrs.toa.features.het.solver.HetSolution;
 import com.duckblade.osrs.toa.features.het.solver.HetSolver;
@@ -8,24 +8,29 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
 import net.runelite.api.Point;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
 @Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 public class HetSolverDebugOverlay extends OverlayPanel
 {
 
-	@Inject
-	private HetSolver hetSolver;
-
-	@Inject
-	private RaidStateTracker raidStateTracker;
+	private final HetSolver hetSolver;
+	private final RaidStateTracker raidStateTracker;
+	private final ToaDebugConfig config;
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (!config.hetSolveDebug())
+		{
+			return null;
+		}
+
 		if (raidStateTracker.getCurrentState().getCurrentRoom() != RaidRoom.HET)
 		{
 			return null;

--- a/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/MenuEntryDumper.java
+++ b/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/MenuEntryDumper.java
@@ -1,0 +1,42 @@
+package com.duckblade.osrs.toa.launcher.debugplugins;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.client.eventbus.Subscribe;
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class MenuEntryDumper
+{
+
+	private final ToaDebugConfig config;
+
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded e)
+	{
+		if (!config.menuEntryDumper())
+		{
+			return;
+		}
+
+		if (e.getOption().equals("Walk here") ||
+			e.getOption().equals("Cancel"))
+		{
+			return;
+		}
+
+		log.debug(
+			"{} | '{}' on '{}' ({}, {})",
+			e.getMenuEntry().getType(),
+			e.getOption(),
+			e.getTarget(),
+			e.getActionParam0(),
+			e.getActionParam1()
+		);
+	}
+
+}

--- a/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/StateOverlay.java
+++ b/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/StateOverlay.java
@@ -1,0 +1,121 @@
+package com.duckblade.osrs.toa.launcher.debugplugins;
+
+import com.duckblade.osrs.toa.features.PathLevelTracker;
+import com.duckblade.osrs.toa.util.RaidCompletionTracker;
+import com.duckblade.osrs.toa.util.RaidStateTracker;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class StateOverlay extends OverlayPanel
+{
+
+	public enum StateDisplays
+	{
+		PATH_LEVELS,
+		RAID_STATE,
+		ROOM_COMPLETIONS,
+	}
+
+	private final ToaDebugConfig config;
+
+	private final PathLevelTracker pathLevelTracker;
+	private final RaidStateTracker raidStateTracker;
+	private final RaidCompletionTracker raidCompletionTracker;
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (config.stateOverlay().isEmpty())
+		{
+			return null;
+		}
+
+		if (config.stateOverlay().contains(StateDisplays.RAID_STATE))
+		{
+			getPanelComponent().getChildren().addAll(
+				List.of(
+					TitleComponent.builder()
+						.color(Color.ORANGE)
+						.text("Raid State")
+						.build(),
+					LineComponent.builder()
+						.left("In Raid")
+						.rightColor(raidStateTracker.getCurrentState().isInRaid() ? Color.GREEN : Color.RED)
+						.right(String.valueOf(raidStateTracker.getCurrentState().isInRaid()))
+						.build(),
+					LineComponent.builder()
+						.left("In Lobby")
+						.rightColor(raidStateTracker.getCurrentState().isInLobby() ? Color.GREEN : Color.RED)
+						.right(String.valueOf(raidStateTracker.getCurrentState().isInLobby()))
+						.build(),
+					LineComponent.builder()
+						.left("Room")
+						.right(String.valueOf(raidStateTracker.getCurrentState().getCurrentRoom()))
+						.build(),
+					LineComponent.builder()
+						.left("Players")
+						.right(String.valueOf(raidStateTracker.getCurrentState().getPlayerCount()))
+						.build()
+				)
+			);
+		}
+
+		if (config.stateOverlay().contains(StateDisplays.ROOM_COMPLETIONS))
+		{
+			getPanelComponent().getChildren().add(
+				TitleComponent.builder()
+					.color(Color.ORANGE)
+					.text("Completion")
+					.build()
+			);
+			for (String boss : raidCompletionTracker.getCompletedBosses())
+			{
+				getPanelComponent().getChildren().add(
+					LineComponent.builder()
+						.right(boss)
+						.build()
+				);
+			}
+		}
+
+		if (config.stateOverlay().contains(StateDisplays.PATH_LEVELS))
+		{
+			getPanelComponent().getChildren().addAll(
+				List.of(
+					TitleComponent.builder()
+						.color(Color.ORANGE)
+						.text("Path Levels")
+						.build(),
+					LineComponent.builder()
+						.left("Zebak")
+						.right(String.valueOf(pathLevelTracker.getZebakPathLevel()))
+						.build(),
+					LineComponent.builder()
+						.left("Kephri")
+						.right(String.valueOf(pathLevelTracker.getKephriPathLevel()))
+						.build(),
+					LineComponent.builder()
+						.left("Akkha")
+						.right(String.valueOf(pathLevelTracker.getAkkhaPathLevel()))
+						.build(),
+					LineComponent.builder()
+						.left("Ba-ba")
+						.right(String.valueOf(pathLevelTracker.getBabaPathLevel()))
+						.build()
+				)
+			);
+		}
+
+		return super.render(graphics);
+	}
+}

--- a/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/ToaDebugConfig.java
+++ b/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/ToaDebugConfig.java
@@ -1,6 +1,8 @@
 package com.duckblade.osrs.toa.launcher.debugplugins;
 
 import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import java.util.Collections;
+import java.util.Set;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -37,6 +39,16 @@ public interface ToaDebugConfig extends Config
 	default boolean menuEntryDumper()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "stateOverlay",
+		description = "",
+		name = "State Overlay"
+	)
+	default Set<StateOverlay.StateDisplays> stateOverlay()
+	{
+		return Collections.emptySet();
 	}
 
 }

--- a/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/ToaDebugConfig.java
+++ b/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/ToaDebugConfig.java
@@ -1,0 +1,42 @@
+package com.duckblade.osrs.toa.launcher.debugplugins;
+
+import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(TombsOfAmascutConfig.CONFIG_GROUP + "Debug")
+public interface ToaDebugConfig extends Config
+{
+
+	@ConfigItem(
+		keyName = "hetSolveDebug",
+		description = "",
+		name = "Het Solve Debug"
+	)
+	default boolean hetSolveDebug()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "akkhaShadowHsl",
+		description = "",
+		name = "Akkha Shadow HSL"
+	)
+	default boolean akkhaShadowHsl()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "menuEntryDumper",
+		description = "",
+		name = "Menu Entry Log"
+	)
+	default boolean menuEntryDumper()
+	{
+		return false;
+	}
+
+}

--- a/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/ToaDebugPlugin.java
+++ b/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/ToaDebugPlugin.java
@@ -1,12 +1,14 @@
-package launcher.debugplugins;
+package com.duckblade.osrs.toa.launcher.debugplugins;
 
 import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import com.google.inject.Provides;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import ch.qos.logback.classic.Logger;
 import net.runelite.client.ui.overlay.OverlayManager;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +29,9 @@ public class ToaDebugPlugin extends Plugin
 	private AkkhaShadowOverridesOverlay shadowOverridesOverlay;
 
 	@Inject
+	private MenuEntryDumper menuEntryDumper;
+
+	@Inject
 	private EventBus eventBus;
 
 	@Override
@@ -34,10 +39,12 @@ public class ToaDebugPlugin extends Plugin
 	{
 		((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.WARN);
 		((Logger) LoggerFactory.getLogger("com.duckblade.osrs.toa")).setLevel(Level.DEBUG);
+		((Logger) LoggerFactory.getLogger("com.duckblade.osrs.toa")).setLevel(Level.DEBUG);
 
 		overlayManager.add(hetSolverDebugOverlay);
 		overlayManager.add(shadowOverridesOverlay);
 		eventBus.register(shadowOverridesOverlay);
+		eventBus.register(menuEntryDumper);
 	}
 
 	@Override
@@ -47,5 +54,12 @@ public class ToaDebugPlugin extends Plugin
 		overlayManager.remove(hetSolverDebugOverlay);
 		overlayManager.remove(shadowOverridesOverlay);
 		eventBus.unregister(shadowOverridesOverlay);
+		eventBus.unregister(menuEntryDumper);
+	}
+
+	@Provides
+	public ToaDebugConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(ToaDebugConfig.class);
 	}
 }

--- a/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/ToaDebugPlugin.java
+++ b/src/test/java/com/duckblade/osrs/toa/launcher/debugplugins/ToaDebugPlugin.java
@@ -32,6 +32,9 @@ public class ToaDebugPlugin extends Plugin
 	private MenuEntryDumper menuEntryDumper;
 
 	@Inject
+	private StateOverlay stateOverlay;
+
+	@Inject
 	private EventBus eventBus;
 
 	@Override
@@ -43,6 +46,7 @@ public class ToaDebugPlugin extends Plugin
 
 		overlayManager.add(hetSolverDebugOverlay);
 		overlayManager.add(shadowOverridesOverlay);
+		overlayManager.add(stateOverlay);
 		eventBus.register(shadowOverridesOverlay);
 		eventBus.register(menuEntryDumper);
 	}
@@ -53,6 +57,7 @@ public class ToaDebugPlugin extends Plugin
 		((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.DEBUG);
 		overlayManager.remove(hetSolverDebugOverlay);
 		overlayManager.remove(shadowOverridesOverlay);
+		overlayManager.remove(stateOverlay);
 		eventBus.unregister(shadowOverridesOverlay);
 		eventBus.unregister(menuEntryDumper);
 	}

--- a/src/test/java/com/duckblade/osrs/toa/util/RaidCompletionTrackerTest.java
+++ b/src/test/java/com/duckblade/osrs/toa/util/RaidCompletionTrackerTest.java
@@ -1,0 +1,57 @@
+package com.duckblade.osrs.toa.util;
+
+import java.util.Collections;
+import java.util.Set;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.events.ChatMessage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RaidCompletionTrackerTest
+{
+
+	@InjectMocks
+	private RaidCompletionTracker raidCompletionTracker;
+
+	@Test
+	void tracksCompletedBosses()
+	{
+		assertEquals(raidCompletionTracker.getCompletedBosses(), Set.of());
+
+		raidCompletionTracker.onChatMessage(message("Challenge complete: Path of Crondis. Duration: 12"));
+		raidCompletionTracker.onChatMessage(message("Challenge complete: Zebak. Duration: 12"));
+		assertEquals(raidCompletionTracker.getCompletedBosses(), Set.of("Path of Crondis", "Zebak"));
+	}
+
+	@Test
+	void resetsWhenNotInRaid()
+	{
+		assertEquals(raidCompletionTracker.getCompletedBosses(), Collections.emptySet());
+
+		raidCompletionTracker.onChatMessage(message("Challenge complete: Path of Crondis. Duration: 12"));
+		raidCompletionTracker.onChatMessage(message("Challenge complete: Zebak. Duration: 12"));
+		raidCompletionTracker.onRaidStateChanged(new RaidStateChanged(null, new RaidState(true, false, null, 1)));
+		assertEquals(raidCompletionTracker.getCompletedBosses(), Set.of());
+
+		raidCompletionTracker.onChatMessage(message("Challenge complete: Path of Het. Duration: 12"));
+		assertEquals(raidCompletionTracker.getCompletedBosses(), Set.of("Path of Het"));
+	}
+
+	private static ChatMessage message(String content)
+	{
+		return new ChatMessage(
+			null,
+			ChatMessageType.GAMEMESSAGE,
+			"",
+			content,
+			"",
+			123
+		);
+	}
+
+
+}


### PR DESCRIPTION
copying over from #118 

via @FiveNine 
> Few things i noticed:
> * original code allowed for case-insensitive filter in the string. That seems to be removed with your changes 👀
> * since we're assigning `allowedItemNames `in `isEnabled`() [[DepositBoxFilter.java#L66](https://github.com/LlemonDuck/tombs-of-amascut/blob/main/src/main/java/com/duckblade/osrs/toa/features/DepositBoxFilter.java#L66)], does that not mean that if the user were to update their filter string while inside the room, it would not be effective immediately and only when the user comes back to the NEXUS the next time? This might feel a little bit jank to not see it update immediately. 😄 I'm assuming that's what the `todo` is there for. Maybe I can set `allowedItemNames` on `WidgetLoaded` event instead? Or maybe there's a way to set it on config update.
> * I believe this update, using `Deposit-` to look for the menu option instead of just `Deposit`, does not block the `Deposit Worn Items`, nor the `Deposit Inventory` buttons which are very dangerous for a missclick.