### PR TITLE
Add Apmeken Issue Helper

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -451,6 +451,18 @@ public interface TombsOfAmascutConfig extends Config
 		return new Color(0x40FFC800, true);
 	}
 
+	@ConfigItem(
+		name = "Issue Helper",
+		description = "Shows skull markers on pillars and vents when the sight player fixes issues.",
+		position = 11,
+		keyName = "apmekenIssueHelper",
+		section = SECTION_APMEKEN
+	)
+	default boolean apmekenIssueHelper()
+	{
+		return true;
+	}
+
 	// Het
 
 	@ConfigItem(

--- a/src/main/java/com/duckblade/osrs/toa/features/apmeken/ApmekenIssueHelper.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/apmeken/ApmekenIssueHelper.java
@@ -5,7 +5,6 @@ import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
 import com.duckblade.osrs.toa.util.RaidRoom;
 import com.duckblade.osrs.toa.util.RaidState;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
-import net.runelite.api.GraphicsObject;
 import net.runelite.api.Model;
 import net.runelite.api.Player;
 import net.runelite.api.RuneLiteObject;
@@ -23,7 +21,6 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.api.events.GameTick;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 
@@ -100,10 +97,10 @@ public class ApmekenIssueHelper implements PluginLifecycleComponent
 	@Subscribe
 	public void onChatMessage(ChatMessage e)
 	{
-		 if (e.getType() != ChatMessageType.GAMEMESSAGE)
-		 {
-		 	return;
-		 }
+		if (e.getType() != ChatMessageType.GAMEMESSAGE)
+		{
+			return;
+		}
 
 		String message = e.getMessage().replaceAll("<.*?>", "");
 		if (message.equals(MESSAGE_ISSUE_SENSED) ||
@@ -134,7 +131,7 @@ public class ApmekenIssueHelper implements PluginLifecycleComponent
 		Player player = (Player) e.getActor();
 		int animationId = player.getAnimation();
 		WorldPoint playerLocation = player.getWorldLocation();
-		
+
 		if (playerLocation == null)
 		{
 			return;
@@ -222,7 +219,7 @@ public class ApmekenIssueHelper implements PluginLifecycleComponent
 		{
 			return;
 		}
-        
+
 		boolean isNorth = worldPoint.getY() >= 2788;
 		int modelId = isNorth ? MODEL_SKULL_SOUTH : MODEL_SKULL_NORTH;
 

--- a/src/main/java/com/duckblade/osrs/toa/features/apmeken/ApmekenIssueHelper.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/apmeken/ApmekenIssueHelper.java
@@ -1,0 +1,273 @@
+package com.duckblade.osrs.toa.features.apmeken;
+
+import com.duckblade.osrs.toa.TombsOfAmascutConfig;
+import com.duckblade.osrs.toa.module.PluginLifecycleComponent;
+import com.duckblade.osrs.toa.util.RaidRoom;
+import com.duckblade.osrs.toa.util.RaidState;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GraphicsObject;
+import net.runelite.api.Model;
+import net.runelite.api.Player;
+import net.runelite.api.RuneLiteObject;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class ApmekenIssueHelper implements PluginLifecycleComponent
+{
+	private static final int ANIMATION_PILLAR_HAMMER = 3676;
+	private static final int ANIMATION_VENT_POUR = 2295;
+
+	private static final int MODEL_SKULL_SOUTH = 45327;
+	private static final int MODEL_SKULL_NORTH = 45330;
+
+	private static final String MESSAGE_ISSUE_SENSED = "You sense an issue somewhere in the room.";
+	private static final String MESSAGE_FUMES_SENSED = "You sense some strange fumes coming from holes in the floor.";
+	private static final String MESSAGE_ROOF_SENSED = "You sense an issue with the roof supports.";
+	private static final String MESSAGE_FUMES_NEUTRALIZED = "Apmeken's Sight guides your group into neutralising some dangerous fumes.";
+	private static final String MESSAGE_FUMES_IGNITE = "The fumes filling the room suddenly ignite!";
+	private static final String MESSAGE_ROOF_REPAIRED = "Apmeken's Sight guides your group into repairing the roof supports.";
+	private static final String MESSAGE_DEBRIS_FALL = "Damaged roof supports cause some debris to fall on you!";
+
+
+	private final Client client;
+	private final EventBus eventBus;
+
+	private boolean issueActive = false;
+
+	private final Map<LocalPoint, RuneLiteObject> activeSkulls = new HashMap<>();
+	private final Map<WorldPoint, Boolean> fixedLocations = new HashMap<>();
+
+	private static final List<WorldPoint> PILLAR_LOCATIONS = List.of(
+		new WorldPoint(12636, 2792, 0), // north-west
+		new WorldPoint(12644, 2792, 0), // north-east
+		new WorldPoint(12636, 2776, 0), // south-west
+		new WorldPoint(12644, 2776, 0)  // south-east
+	);
+
+	private static final List<WorldPoint> VENT_LOCATIONS = List.of(
+		new WorldPoint(12632, 2788, 0), // north-west
+		new WorldPoint(12648, 2788, 0), // north-east
+		new WorldPoint(12632, 2780, 0), // south-west
+		new WorldPoint(12648, 2780, 0)  // south-east
+	);
+
+	@Override
+	public boolean isEnabled(TombsOfAmascutConfig config, RaidState raidState)
+	{
+		return config.apmekenIssueHelper() && raidState.getCurrentRoom() == RaidRoom.APMEKEN;
+	}
+
+	@Override
+	public void startUp()
+	{
+		eventBus.register(this);
+		reset();
+	}
+
+	@Override
+	public void shutDown()
+	{
+		eventBus.unregister(this);
+		clearAllSkulls();
+		reset();
+	}
+
+	private void reset()
+	{
+		issueActive = false;
+		clearAllSkulls();
+		fixedLocations.clear();
+	}
+
+	@Subscribe
+	public void onChatMessage(ChatMessage e)
+	{
+		 if (e.getType() != ChatMessageType.GAMEMESSAGE)
+		 {
+		 	return;
+		 }
+
+		String message = e.getMessage().replaceAll("<.*?>", "");
+		if (message.equals(MESSAGE_ISSUE_SENSED) ||
+			message.equals(MESSAGE_FUMES_SENSED) ||
+			message.equals(MESSAGE_ROOF_SENSED))
+		{
+			issueActive = true;
+		}
+		else if (message.equals(MESSAGE_FUMES_NEUTRALIZED) ||
+			message.equals(MESSAGE_FUMES_IGNITE) ||
+			message.equals(MESSAGE_ROOF_REPAIRED) ||
+			message.equals(MESSAGE_DEBRIS_FALL))
+		{
+			clearAllSkulls();
+			fixedLocations.clear();
+			issueActive = false;
+		}
+	}
+
+	@Subscribe
+	public void onAnimationChanged(AnimationChanged e)
+	{
+		if (!(e.getActor() instanceof Player))
+		{
+			return;
+		}
+
+		Player player = (Player) e.getActor();
+		int animationId = player.getAnimation();
+		WorldPoint playerLocation = player.getWorldLocation();
+		
+		if (playerLocation == null)
+		{
+			return;
+		}
+		if (animationId == ANIMATION_PILLAR_HAMMER)
+		{
+			WorldPoint fixedLocation = findNearestPillar(playerLocation);
+			if (fixedLocation != null)
+			{
+				handleIssueFixed(fixedLocation, PILLAR_LOCATIONS, issueActive);
+				issueActive = false; // Just to be able to distinguish between drawing skulls on other locations or not
+			}
+		}
+		else if (animationId == ANIMATION_VENT_POUR)
+		{
+			WorldPoint fixedLocation = findVentAtLocation(playerLocation);
+			if (fixedLocation != null)
+			{
+				handleIssueFixed(fixedLocation, VENT_LOCATIONS, issueActive);
+				issueActive = false; // Just to be able to distinguish between drawing skulls on other locations or not
+			}
+		}
+	}
+
+	private void handleIssueFixed(WorldPoint fixedLocation, List<WorldPoint> allLocations, boolean issueActive)
+	{
+		fixedLocations.put(fixedLocation, true);
+		removeSkullAtTile(fixedLocation);
+
+		if (issueActive)
+		{
+			showSkullsOnOtherLocations(fixedLocation, allLocations);
+		}
+	}
+
+	private void showSkullsOnOtherLocations(WorldPoint fixedLocation, List<WorldPoint> allLocations)
+	{
+		for (WorldPoint location : allLocations)
+		{
+			if (!location.equals(fixedLocation) && !fixedLocations.containsKey(location))
+			{
+				showSkullOnTile(location);
+			}
+		}
+	}
+
+	private WorldPoint findVentAtLocation(WorldPoint playerLocation)
+	{
+		for (WorldPoint vent : VENT_LOCATIONS)
+		{
+			if (vent.equals(playerLocation))
+			{
+				return vent;
+			}
+		}
+		return null;
+	}
+
+	private WorldPoint findNearestPillar(WorldPoint playerLocation)
+	{
+		WorldPoint nearest = null;
+		double minDistance = Double.MAX_VALUE;
+		for (WorldPoint pillar : PILLAR_LOCATIONS)
+		{
+			double distance = playerLocation.distanceTo(pillar);
+			if (distance < minDistance)
+			{
+				minDistance = distance;
+				nearest = pillar;
+			}
+		}
+
+		return nearest;
+	}
+
+	private void showSkullOnTile(WorldPoint worldPoint)
+	{
+		LocalPoint localPoint = LocalPoint.fromWorld(client, worldPoint);
+		if (localPoint == null)
+		{
+			return;
+		}
+
+		if (activeSkulls.containsKey(localPoint))
+		{
+			return;
+		}
+        
+		boolean isNorth = worldPoint.getY() >= 2788;
+		int modelId = isNorth ? MODEL_SKULL_SOUTH : MODEL_SKULL_NORTH;
+
+		Model model = client.loadModel(modelId);
+		if (model == null)
+		{
+			return;
+		}
+
+
+		RuneLiteObject rlObject = client.createRuneLiteObject();
+		rlObject.setLocation(localPoint, client.getPlane());
+		rlObject.setModel(model);
+		rlObject.setActive(true);
+		client.registerRuneLiteObject(rlObject);
+		activeSkulls.put(localPoint, rlObject);
+	}
+
+	private void clearAllSkulls()
+	{
+		for (RuneLiteObject rlObject : activeSkulls.values())
+		{
+			if (rlObject != null && client.isRuneLiteObjectRegistered(rlObject))
+			{
+				client.removeRuneLiteObject(rlObject);
+			}
+		}
+		activeSkulls.clear();
+	}
+
+	private void removeSkullAtTile(WorldPoint worldPoint)
+	{
+		LocalPoint localPoint = LocalPoint.fromWorld(client, worldPoint);
+		if (localPoint == null)
+		{
+			return;
+		}
+
+
+		RuneLiteObject rlObject = activeSkulls.remove(localPoint);
+		if (rlObject != null && client.isRuneLiteObjectRegistered(rlObject))
+		{
+			client.removeRuneLiteObject(rlObject);
+		}
+	}
+
+}
+

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -137,7 +137,7 @@ public class TombsOfAmascutModule extends AbstractModule
 			akkhaShadowHealthOverlay,
 			apmekenBaboonIndicator,
 			apmekenBaboonIndicatorOverlay,
-			apmekenIssueHelper
+			apmekenIssueHelper,
 			apmekenWaveInstaller,
 			babaSarcophagusWarning,
 			beamTimerOverlay,

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -8,31 +8,33 @@ import com.duckblade.osrs.toa.features.DepositBoxFilterOverlay;
 import com.duckblade.osrs.toa.features.FadeDisabler;
 import com.duckblade.osrs.toa.features.InvocationScreenshot;
 import com.duckblade.osrs.toa.features.LeftClickBankAll;
+import com.duckblade.osrs.toa.features.PathLevelTracker;
+import com.duckblade.osrs.toa.features.QuickProceedSwaps;
 import com.duckblade.osrs.toa.features.SmellingSaltsCooldown;
-import com.duckblade.osrs.toa.features.boss.akkha.AkkhaShadowHealth;
-import com.duckblade.osrs.toa.features.boss.akkha.AkkhaShadowHealthOverlay;
 import com.duckblade.osrs.toa.features.apmeken.ApmekenBaboonIndicator;
 import com.duckblade.osrs.toa.features.apmeken.ApmekenBaboonIndicatorOverlay;
 import com.duckblade.osrs.toa.features.apmeken.ApmekenIssueHelper;
+import com.duckblade.osrs.toa.features.apmeken.ApmekenWaveInstaller;
+import com.duckblade.osrs.toa.features.boss.akkha.AkkhaShadowHealth;
+import com.duckblade.osrs.toa.features.boss.akkha.AkkhaShadowHealthOverlay;
 import com.duckblade.osrs.toa.features.boss.baba.BabaSarcophagusWarning;
 import com.duckblade.osrs.toa.features.boss.kephri.swarmer.SwarmerDataManager;
 import com.duckblade.osrs.toa.features.boss.kephri.swarmer.SwarmerOverlay;
 import com.duckblade.osrs.toa.features.boss.kephri.swarmer.SwarmerPanelManager;
+import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerOverlay;
+import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerTracker;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeOverlay;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxePreventEntry;
+import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeSwap;
 import com.duckblade.osrs.toa.features.het.solver.HetSolver;
 import com.duckblade.osrs.toa.features.het.solver.HetSolverOverlay;
 import com.duckblade.osrs.toa.features.hporbs.HpOrbManager;
-import com.duckblade.osrs.toa.features.QuickProceedSwaps;
-import com.duckblade.osrs.toa.features.apmeken.ApmekenWaveInstaller;
-import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerOverlay;
-import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerTracker;
-import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeSwap;
 import com.duckblade.osrs.toa.features.invocationpresets.InvocationPresetsManager;
-import com.duckblade.osrs.toa.features.PathLevelTracker;
 import com.duckblade.osrs.toa.features.pointstracker.PartyPointsTracker;
 import com.duckblade.osrs.toa.features.pointstracker.PointsOverlay;
 import com.duckblade.osrs.toa.features.pointstracker.PointsTracker;
+import com.duckblade.osrs.toa.features.pointstracker.PurpleWeightingManager;
+import com.duckblade.osrs.toa.features.pointstracker.PurpleWeightingPartyBoardManager;
 import com.duckblade.osrs.toa.features.scabaras.SkipObeliskOverlay;
 import com.duckblade.osrs.toa.features.scabaras.overlay.AdditionPuzzleSolver;
 import com.duckblade.osrs.toa.features.scabaras.overlay.LightPuzzleSolver;
@@ -41,19 +43,22 @@ import com.duckblade.osrs.toa.features.scabaras.overlay.ObeliskPuzzleSolver;
 import com.duckblade.osrs.toa.features.scabaras.overlay.ScabarasOverlayManager;
 import com.duckblade.osrs.toa.features.scabaras.overlay.SequencePuzzleSolver;
 import com.duckblade.osrs.toa.features.scabaras.panel.ScabarasPanelManager;
+import com.duckblade.osrs.toa.features.timetracking.SplitsInfoBox;
 import com.duckblade.osrs.toa.features.timetracking.SplitsOverlay;
 import com.duckblade.osrs.toa.features.timetracking.SplitsTracker;
 import com.duckblade.osrs.toa.features.timetracking.TargetTimeManager;
 import com.duckblade.osrs.toa.features.tomb.CursedPhalanxDetector;
 import com.duckblade.osrs.toa.features.tomb.DryStreakTracker;
-import com.duckblade.osrs.toa.features.tomb.SarcophagusRecolorer;
 import com.duckblade.osrs.toa.features.tomb.SarcophagusOpeningSoundPlayer;
+import com.duckblade.osrs.toa.features.tomb.SarcophagusRecolorer;
 import com.duckblade.osrs.toa.features.updatenotifier.UpdateNotifier;
+import com.duckblade.osrs.toa.util.RaidCompletionTracker;
 import com.duckblade.osrs.toa.util.RaidStateTracker;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.google.inject.multibindings.Multibinder;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.ConfigManager;
 
@@ -64,56 +69,122 @@ public class TombsOfAmascutModule extends AbstractModule
 	@Override
 	protected void configure()
 	{
-		Multibinder<PluginLifecycleComponent> lifecycleComponents = Multibinder.newSetBinder(binder(), PluginLifecycleComponent.class);
-		lifecycleComponents.addBinding().to(AdditionPuzzleSolver.class);
-		lifecycleComponents.addBinding().to(AdrenalineCooldown.class);
-		lifecycleComponents.addBinding().to(AkkhaShadowHealth.class);
-		lifecycleComponents.addBinding().to(AkkhaShadowHealthOverlay.class);
-		lifecycleComponents.addBinding().to(ApmekenBaboonIndicator.class);
-		lifecycleComponents.addBinding().to(ApmekenBaboonIndicatorOverlay.class);
-		lifecycleComponents.addBinding().to(ApmekenIssueHelper.class);
-		lifecycleComponents.addBinding().to(ApmekenWaveInstaller.class);
-		lifecycleComponents.addBinding().to(BabaSarcophagusWarning.class);
-		lifecycleComponents.addBinding().to(BeamTimerOverlay.class);
-		lifecycleComponents.addBinding().to(BeamTimerTracker.class);
-		lifecycleComponents.addBinding().to(CameraShakeDisabler.class);
-		lifecycleComponents.addBinding().to(CursedPhalanxDetector.class);
-		lifecycleComponents.addBinding().to(DepositBoxFilter.class);
-		lifecycleComponents.addBinding().to(DepositBoxFilterOverlay.class);
-		lifecycleComponents.addBinding().to(DepositPickaxeOverlay.class);
-		lifecycleComponents.addBinding().to(DepositPickaxePreventEntry.class);
-		lifecycleComponents.addBinding().to(DepositPickaxeSwap.class);
-		lifecycleComponents.addBinding().to(DryStreakTracker.class);
-		lifecycleComponents.addBinding().to(FadeDisabler.class);
-		lifecycleComponents.addBinding().to(HetSolver.class);
-		lifecycleComponents.addBinding().to(HetSolverOverlay.class);
-		lifecycleComponents.addBinding().to(HpOrbManager.class);
-		lifecycleComponents.addBinding().to(InvocationPresetsManager.class);
-		lifecycleComponents.addBinding().to(InvocationScreenshot.class);
-		lifecycleComponents.addBinding().to(LeftClickBankAll.class);
-		lifecycleComponents.addBinding().to(LightPuzzleSolver.class);
-		lifecycleComponents.addBinding().to(MatchingPuzzleSolver.class);
-		lifecycleComponents.addBinding().to(ObeliskPuzzleSolver.class);
-		lifecycleComponents.addBinding().to(PartyPointsTracker.class);
-		lifecycleComponents.addBinding().to(PathLevelTracker.class);
-		lifecycleComponents.addBinding().to(PointsOverlay.class);
-		lifecycleComponents.addBinding().to(PointsTracker.class);
-		lifecycleComponents.addBinding().to(QuickProceedSwaps.class);
-		lifecycleComponents.addBinding().to(RaidStateTracker.class);
-		lifecycleComponents.addBinding().to(SarcophagusOpeningSoundPlayer.class);
-		lifecycleComponents.addBinding().to(SarcophagusRecolorer.class);
-		lifecycleComponents.addBinding().to(ScabarasOverlayManager.class);
-		lifecycleComponents.addBinding().to(ScabarasPanelManager.class);
-		lifecycleComponents.addBinding().to(SequencePuzzleSolver.class);
-		lifecycleComponents.addBinding().to(SkipObeliskOverlay.class);
-		lifecycleComponents.addBinding().to(SmellingSaltsCooldown.class);
-		lifecycleComponents.addBinding().to(SplitsOverlay.class);
-		lifecycleComponents.addBinding().to(SplitsTracker.class);
-		lifecycleComponents.addBinding().to(SwarmerOverlay.class);
-		lifecycleComponents.addBinding().to(SwarmerPanelManager.class);
-		lifecycleComponents.addBinding().to(SwarmerDataManager.class);
-		lifecycleComponents.addBinding().to(TargetTimeManager.class);
-		lifecycleComponents.addBinding().to(UpdateNotifier.class);
+		bind(ComponentManager.class);
+	}
+
+
+	@Provides
+	Set<PluginLifecycleComponent> lifecycleComponents(
+		AdditionPuzzleSolver additionPuzzleSolver,
+		AdrenalineCooldown adrenalineCooldown,
+		AkkhaShadowHealth akkhaShadowHealth,
+		AkkhaShadowHealthOverlay akkhaShadowHealthOverlay,
+		ApmekenBaboonIndicator apmekenBaboonIndicator,
+		ApmekenBaboonIndicatorOverlay apmekenBaboonIndicatorOverlay,
+		ApmekenIssueHelper apmekenIssueHelper,
+		ApmekenWaveInstaller apmekenWaveInstaller,
+		BabaSarcophagusWarning babaSarcophagusWarning,
+		BeamTimerOverlay beamTimerOverlay,
+		BeamTimerTracker beamTimerTracker,
+		CameraShakeDisabler cameraShakeDisabler,
+		CursedPhalanxDetector cursedPhalanxDetector,
+		DepositBoxFilter depositBoxFilter,
+		DepositBoxFilterOverlay depositBoxFilterOverlay,
+		DepositPickaxeOverlay depositPickaxeOverlay,
+		DepositPickaxePreventEntry depositPickaxePreventEntry,
+		DepositPickaxeSwap depositPickaxeSwap,
+		DryStreakTracker dryStreakTracker,
+		FadeDisabler fadeDisabler,
+		HetSolver hetSolver,
+		HetSolverOverlay hetSolverOverlay,
+		HpOrbManager hpOrbManager,
+		InvocationPresetsManager invocationPresetsManager,
+		InvocationScreenshot invocationScreenshot,
+		LeftClickBankAll leftClickBankAll,
+		LightPuzzleSolver lightPuzzleSolver,
+		MatchingPuzzleSolver matchingPuzzleSolver,
+		ObeliskPuzzleSolver obeliskPuzzleSolver,
+		PartyPointsTracker partyPointsTracker,
+		PathLevelTracker pathLevelTracker,
+		PointsOverlay pointsOverlay,
+		PointsTracker pointsTracker,
+		PurpleWeightingManager purpleWeightingManager,
+		PurpleWeightingPartyBoardManager purpleWeightingPartyBoardManager,
+		QuickProceedSwaps quickProceedSwaps,
+		RaidCompletionTracker raidCompletionTracker,
+		RaidStateTracker raidStateTracker,
+		SarcophagusOpeningSoundPlayer sarcophagusOpeningSoundPlayer,
+		SarcophagusRecolorer sarcophagusRecolorer,
+		ScabarasOverlayManager scabarasOverlayManager,
+		ScabarasPanelManager scabarasPanelManager,
+		SequencePuzzleSolver sequencePuzzleSolver,
+		SkipObeliskOverlay skipObeliskOverlay,
+		SmellingSaltsCooldown smellingSaltsCooldown,
+		SplitsInfoBox splitsInfoBox,
+		SplitsOverlay splitsOverlay,
+		SplitsTracker splitsTracker,
+		SwarmerOverlay swarmerOverlay,
+		SwarmerPanelManager swarmerPanelManager,
+		SwarmerDataManager swarmerDataManager,
+		TargetTimeManager targetTimeManager,
+		UpdateNotifier updateNotifier
+	)
+	{
+		return ImmutableSet.of(
+			additionPuzzleSolver,
+			adrenalineCooldown,
+			akkhaShadowHealth,
+			akkhaShadowHealthOverlay,
+			apmekenBaboonIndicator,
+			apmekenBaboonIndicatorOverlay,
+			apmekenIssueHelper
+			apmekenWaveInstaller,
+			babaSarcophagusWarning,
+			beamTimerOverlay,
+			beamTimerTracker,
+			cameraShakeDisabler,
+			cursedPhalanxDetector,
+			depositBoxFilter,
+			depositBoxFilterOverlay,
+			depositPickaxeOverlay,
+			depositPickaxePreventEntry,
+			depositPickaxeSwap,
+			dryStreakTracker,
+			fadeDisabler,
+			hetSolver,
+			hetSolverOverlay,
+			hpOrbManager,
+			invocationPresetsManager,
+			invocationScreenshot,
+			leftClickBankAll,
+			lightPuzzleSolver,
+			matchingPuzzleSolver,
+			obeliskPuzzleSolver,
+			partyPointsTracker,
+			pathLevelTracker,
+			pointsOverlay,
+			pointsTracker,
+			purpleWeightingManager,
+			purpleWeightingPartyBoardManager,
+			quickProceedSwaps,
+			raidCompletionTracker,
+			raidStateTracker,
+			sarcophagusOpeningSoundPlayer,
+			sarcophagusRecolorer,
+			scabarasOverlayManager,
+			scabarasPanelManager,
+			sequencePuzzleSolver,
+			skipObeliskOverlay,
+			smellingSaltsCooldown,
+			splitsInfoBox,
+			splitsOverlay,
+			splitsTracker,
+			swarmerOverlay,
+			swarmerPanelManager,
+			swarmerDataManager,
+			targetTimeManager,
+			updateNotifier
+		);
 	}
 
 	@Provides

--- a/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
+++ b/src/main/java/com/duckblade/osrs/toa/module/TombsOfAmascutModule.java
@@ -8,32 +8,31 @@ import com.duckblade.osrs.toa.features.DepositBoxFilterOverlay;
 import com.duckblade.osrs.toa.features.FadeDisabler;
 import com.duckblade.osrs.toa.features.InvocationScreenshot;
 import com.duckblade.osrs.toa.features.LeftClickBankAll;
-import com.duckblade.osrs.toa.features.PathLevelTracker;
-import com.duckblade.osrs.toa.features.QuickProceedSwaps;
 import com.duckblade.osrs.toa.features.SmellingSaltsCooldown;
-import com.duckblade.osrs.toa.features.apmeken.ApmekenBaboonIndicator;
-import com.duckblade.osrs.toa.features.apmeken.ApmekenBaboonIndicatorOverlay;
-import com.duckblade.osrs.toa.features.apmeken.ApmekenWaveInstaller;
 import com.duckblade.osrs.toa.features.boss.akkha.AkkhaShadowHealth;
 import com.duckblade.osrs.toa.features.boss.akkha.AkkhaShadowHealthOverlay;
+import com.duckblade.osrs.toa.features.apmeken.ApmekenBaboonIndicator;
+import com.duckblade.osrs.toa.features.apmeken.ApmekenBaboonIndicatorOverlay;
+import com.duckblade.osrs.toa.features.apmeken.ApmekenIssueHelper;
 import com.duckblade.osrs.toa.features.boss.baba.BabaSarcophagusWarning;
 import com.duckblade.osrs.toa.features.boss.kephri.swarmer.SwarmerDataManager;
 import com.duckblade.osrs.toa.features.boss.kephri.swarmer.SwarmerOverlay;
 import com.duckblade.osrs.toa.features.boss.kephri.swarmer.SwarmerPanelManager;
-import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerOverlay;
-import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerTracker;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeOverlay;
 import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxePreventEntry;
-import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeSwap;
 import com.duckblade.osrs.toa.features.het.solver.HetSolver;
 import com.duckblade.osrs.toa.features.het.solver.HetSolverOverlay;
 import com.duckblade.osrs.toa.features.hporbs.HpOrbManager;
+import com.duckblade.osrs.toa.features.QuickProceedSwaps;
+import com.duckblade.osrs.toa.features.apmeken.ApmekenWaveInstaller;
+import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerOverlay;
+import com.duckblade.osrs.toa.features.het.beamtimer.BeamTimerTracker;
+import com.duckblade.osrs.toa.features.het.pickaxe.DepositPickaxeSwap;
 import com.duckblade.osrs.toa.features.invocationpresets.InvocationPresetsManager;
+import com.duckblade.osrs.toa.features.PathLevelTracker;
 import com.duckblade.osrs.toa.features.pointstracker.PartyPointsTracker;
 import com.duckblade.osrs.toa.features.pointstracker.PointsOverlay;
 import com.duckblade.osrs.toa.features.pointstracker.PointsTracker;
-import com.duckblade.osrs.toa.features.pointstracker.PurpleWeightingManager;
-import com.duckblade.osrs.toa.features.pointstracker.PurpleWeightingPartyBoardManager;
 import com.duckblade.osrs.toa.features.scabaras.SkipObeliskOverlay;
 import com.duckblade.osrs.toa.features.scabaras.overlay.AdditionPuzzleSolver;
 import com.duckblade.osrs.toa.features.scabaras.overlay.LightPuzzleSolver;
@@ -42,22 +41,19 @@ import com.duckblade.osrs.toa.features.scabaras.overlay.ObeliskPuzzleSolver;
 import com.duckblade.osrs.toa.features.scabaras.overlay.ScabarasOverlayManager;
 import com.duckblade.osrs.toa.features.scabaras.overlay.SequencePuzzleSolver;
 import com.duckblade.osrs.toa.features.scabaras.panel.ScabarasPanelManager;
-import com.duckblade.osrs.toa.features.timetracking.SplitsInfoBox;
 import com.duckblade.osrs.toa.features.timetracking.SplitsOverlay;
 import com.duckblade.osrs.toa.features.timetracking.SplitsTracker;
 import com.duckblade.osrs.toa.features.timetracking.TargetTimeManager;
 import com.duckblade.osrs.toa.features.tomb.CursedPhalanxDetector;
 import com.duckblade.osrs.toa.features.tomb.DryStreakTracker;
-import com.duckblade.osrs.toa.features.tomb.SarcophagusOpeningSoundPlayer;
 import com.duckblade.osrs.toa.features.tomb.SarcophagusRecolorer;
+import com.duckblade.osrs.toa.features.tomb.SarcophagusOpeningSoundPlayer;
 import com.duckblade.osrs.toa.features.updatenotifier.UpdateNotifier;
-import com.duckblade.osrs.toa.util.RaidCompletionTracker;
 import com.duckblade.osrs.toa.util.RaidStateTracker;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import java.util.Set;
+import com.google.inject.multibindings.Multibinder;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.ConfigManager;
 
@@ -68,120 +64,56 @@ public class TombsOfAmascutModule extends AbstractModule
 	@Override
 	protected void configure()
 	{
-		bind(ComponentManager.class);
-	}
-
-
-	@Provides
-	Set<PluginLifecycleComponent> lifecycleComponents(
-		AdditionPuzzleSolver additionPuzzleSolver,
-		AdrenalineCooldown adrenalineCooldown,
-		AkkhaShadowHealth akkhaShadowHealth,
-		AkkhaShadowHealthOverlay akkhaShadowHealthOverlay,
-		ApmekenBaboonIndicator apmekenBaboonIndicator,
-		ApmekenBaboonIndicatorOverlay apmekenBaboonIndicatorOverlay,
-		ApmekenWaveInstaller apmekenWaveInstaller,
-		BabaSarcophagusWarning babaSarcophagusWarning,
-		BeamTimerOverlay beamTimerOverlay,
-		BeamTimerTracker beamTimerTracker,
-		CameraShakeDisabler cameraShakeDisabler,
-		CursedPhalanxDetector cursedPhalanxDetector,
-		DepositBoxFilter depositBoxFilter,
-		DepositBoxFilterOverlay depositBoxFilterOverlay,
-		DepositPickaxeOverlay depositPickaxeOverlay,
-		DepositPickaxePreventEntry depositPickaxePreventEntry,
-		DepositPickaxeSwap depositPickaxeSwap,
-		DryStreakTracker dryStreakTracker,
-		FadeDisabler fadeDisabler,
-		HetSolver hetSolver,
-		HetSolverOverlay hetSolverOverlay,
-		HpOrbManager hpOrbManager,
-		InvocationPresetsManager invocationPresetsManager,
-		InvocationScreenshot invocationScreenshot,
-		LeftClickBankAll leftClickBankAll,
-		LightPuzzleSolver lightPuzzleSolver,
-		MatchingPuzzleSolver matchingPuzzleSolver,
-		ObeliskPuzzleSolver obeliskPuzzleSolver,
-		PartyPointsTracker partyPointsTracker,
-		PathLevelTracker pathLevelTracker,
-		PointsOverlay pointsOverlay,
-		PointsTracker pointsTracker,
-		PurpleWeightingManager purpleWeightingManager,
-		PurpleWeightingPartyBoardManager purpleWeightingPartyBoardManager,
-		QuickProceedSwaps quickProceedSwaps,
-		RaidCompletionTracker raidCompletionTracker,
-		RaidStateTracker raidStateTracker,
-		SarcophagusOpeningSoundPlayer sarcophagusOpeningSoundPlayer,
-		SarcophagusRecolorer sarcophagusRecolorer,
-		ScabarasOverlayManager scabarasOverlayManager,
-		ScabarasPanelManager scabarasPanelManager,
-		SequencePuzzleSolver sequencePuzzleSolver,
-		SkipObeliskOverlay skipObeliskOverlay,
-		SmellingSaltsCooldown smellingSaltsCooldown,
-		SplitsInfoBox splitsInfoBox,
-		SplitsOverlay splitsOverlay,
-		SplitsTracker splitsTracker,
-		SwarmerOverlay swarmerOverlay,
-		SwarmerPanelManager swarmerPanelManager,
-		SwarmerDataManager swarmerDataManager,
-		TargetTimeManager targetTimeManager,
-		UpdateNotifier updateNotifier
-	)
-	{
-		return ImmutableSet.of(
-			additionPuzzleSolver,
-			adrenalineCooldown,
-			akkhaShadowHealth,
-			akkhaShadowHealthOverlay,
-			apmekenBaboonIndicator,
-			apmekenBaboonIndicatorOverlay,
-			apmekenWaveInstaller,
-			babaSarcophagusWarning,
-			beamTimerOverlay,
-			beamTimerTracker,
-			cameraShakeDisabler,
-			cursedPhalanxDetector,
-			depositBoxFilter,
-			depositBoxFilterOverlay,
-			depositPickaxeOverlay,
-			depositPickaxePreventEntry,
-			depositPickaxeSwap,
-			dryStreakTracker,
-			fadeDisabler,
-			hetSolver,
-			hetSolverOverlay,
-			hpOrbManager,
-			invocationPresetsManager,
-			invocationScreenshot,
-			leftClickBankAll,
-			lightPuzzleSolver,
-			matchingPuzzleSolver,
-			obeliskPuzzleSolver,
-			partyPointsTracker,
-			pathLevelTracker,
-			pointsOverlay,
-			pointsTracker,
-			purpleWeightingManager,
-			purpleWeightingPartyBoardManager,
-			quickProceedSwaps,
-			raidCompletionTracker,
-			raidStateTracker,
-			sarcophagusOpeningSoundPlayer,
-			sarcophagusRecolorer,
-			scabarasOverlayManager,
-			scabarasPanelManager,
-			sequencePuzzleSolver,
-			skipObeliskOverlay,
-			smellingSaltsCooldown,
-			splitsInfoBox,
-			splitsOverlay,
-			splitsTracker,
-			swarmerOverlay,
-			swarmerPanelManager,
-			swarmerDataManager,
-			targetTimeManager,
-			updateNotifier
-		);
+		Multibinder<PluginLifecycleComponent> lifecycleComponents = Multibinder.newSetBinder(binder(), PluginLifecycleComponent.class);
+		lifecycleComponents.addBinding().to(AdditionPuzzleSolver.class);
+		lifecycleComponents.addBinding().to(AdrenalineCooldown.class);
+		lifecycleComponents.addBinding().to(AkkhaShadowHealth.class);
+		lifecycleComponents.addBinding().to(AkkhaShadowHealthOverlay.class);
+		lifecycleComponents.addBinding().to(ApmekenBaboonIndicator.class);
+		lifecycleComponents.addBinding().to(ApmekenBaboonIndicatorOverlay.class);
+		lifecycleComponents.addBinding().to(ApmekenIssueHelper.class);
+		lifecycleComponents.addBinding().to(ApmekenWaveInstaller.class);
+		lifecycleComponents.addBinding().to(BabaSarcophagusWarning.class);
+		lifecycleComponents.addBinding().to(BeamTimerOverlay.class);
+		lifecycleComponents.addBinding().to(BeamTimerTracker.class);
+		lifecycleComponents.addBinding().to(CameraShakeDisabler.class);
+		lifecycleComponents.addBinding().to(CursedPhalanxDetector.class);
+		lifecycleComponents.addBinding().to(DepositBoxFilter.class);
+		lifecycleComponents.addBinding().to(DepositBoxFilterOverlay.class);
+		lifecycleComponents.addBinding().to(DepositPickaxeOverlay.class);
+		lifecycleComponents.addBinding().to(DepositPickaxePreventEntry.class);
+		lifecycleComponents.addBinding().to(DepositPickaxeSwap.class);
+		lifecycleComponents.addBinding().to(DryStreakTracker.class);
+		lifecycleComponents.addBinding().to(FadeDisabler.class);
+		lifecycleComponents.addBinding().to(HetSolver.class);
+		lifecycleComponents.addBinding().to(HetSolverOverlay.class);
+		lifecycleComponents.addBinding().to(HpOrbManager.class);
+		lifecycleComponents.addBinding().to(InvocationPresetsManager.class);
+		lifecycleComponents.addBinding().to(InvocationScreenshot.class);
+		lifecycleComponents.addBinding().to(LeftClickBankAll.class);
+		lifecycleComponents.addBinding().to(LightPuzzleSolver.class);
+		lifecycleComponents.addBinding().to(MatchingPuzzleSolver.class);
+		lifecycleComponents.addBinding().to(ObeliskPuzzleSolver.class);
+		lifecycleComponents.addBinding().to(PartyPointsTracker.class);
+		lifecycleComponents.addBinding().to(PathLevelTracker.class);
+		lifecycleComponents.addBinding().to(PointsOverlay.class);
+		lifecycleComponents.addBinding().to(PointsTracker.class);
+		lifecycleComponents.addBinding().to(QuickProceedSwaps.class);
+		lifecycleComponents.addBinding().to(RaidStateTracker.class);
+		lifecycleComponents.addBinding().to(SarcophagusOpeningSoundPlayer.class);
+		lifecycleComponents.addBinding().to(SarcophagusRecolorer.class);
+		lifecycleComponents.addBinding().to(ScabarasOverlayManager.class);
+		lifecycleComponents.addBinding().to(ScabarasPanelManager.class);
+		lifecycleComponents.addBinding().to(SequencePuzzleSolver.class);
+		lifecycleComponents.addBinding().to(SkipObeliskOverlay.class);
+		lifecycleComponents.addBinding().to(SmellingSaltsCooldown.class);
+		lifecycleComponents.addBinding().to(SplitsOverlay.class);
+		lifecycleComponents.addBinding().to(SplitsTracker.class);
+		lifecycleComponents.addBinding().to(SwarmerOverlay.class);
+		lifecycleComponents.addBinding().to(SwarmerPanelManager.class);
+		lifecycleComponents.addBinding().to(SwarmerDataManager.class);
+		lifecycleComponents.addBinding().to(TargetTimeManager.class);
+		lifecycleComponents.addBinding().to(UpdateNotifier.class);
 	}
 
 	@Provides


### PR DESCRIPTION
In team raids, this will look at other player's animations and if any player is seen fixing an issue (pillar or vent) it will highlight the issue even for the players that don't have sight instantly. Instead of highlighting, it just spawns the same skull as done by the game for player with sight.

This feature is not presenting any information that is not already available to a player as it only marks the issue if another player is seen solving the issue. As we are only basing it off other players' animations, this feature does not help with Corruption issue.