### PR TITLE
Add option to only label healing swarms

### DIFF
--- a/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
+++ b/src/main/java/com/duckblade/osrs/toa/TombsOfAmascutConfig.java
@@ -311,6 +311,18 @@ public interface TombsOfAmascutConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		name = "Only Label Healing Swarms",
+		description = "Only display labels for swarms that can heal Kephri.",
+		position = 6,
+		keyName = "swarmerOnlyLabelHealing",
+		section = SECTION_KEPHRI
+	)
+	default boolean swarmerOnlyLabelHealing()
+	{
+		return false;
+	}
+
 	// Apmeken
 
 	@ConfigItem(

--- a/src/main/java/com/duckblade/osrs/toa/features/boss/kephri/swarmer/SwarmerOverlay.java
+++ b/src/main/java/com/duckblade/osrs/toa/features/boss/kephri/swarmer/SwarmerOverlay.java
@@ -63,6 +63,7 @@ public class SwarmerOverlay extends Overlay implements PluginLifecycleComponent
 
 	private boolean isKephriDowned;
 	private int lastSpawnTick;
+	private int kephriNpcIndex = -1;
 
 	@Inject
 	public SwarmerOverlay(Client client, EventBus eventBus, OverlayManager overlayManager, TombsOfAmascutConfig config, SwarmerDataManager swarmerDataManager, SwarmerPanel swarmerPanel)
@@ -110,6 +111,7 @@ public class SwarmerOverlay extends Overlay implements PluginLifecycleComponent
 		lastSpawnTick = -1;
 		waveNumber = 0;
 		kephriDownCount = 0;
+		kephriNpcIndex = -1;
 	}
 
 	@Subscribe
@@ -177,6 +179,8 @@ public class SwarmerOverlay extends Overlay implements PluginLifecycleComponent
 
 	private void handleKephriAnimationChanged(NPC npc)
 	{
+		kephriNpcIndex = npc.getIndex();
+
 		if (!isKephriDowned && npc.getAnimation() == ANIMATION_KEPHRI_DOWN)
 		{
 			isKephriDowned = true;
@@ -188,6 +192,44 @@ public class SwarmerOverlay extends Overlay implements PluginLifecycleComponent
 		{
 			isKephriDowned = false;
 		}
+	}
+
+	private boolean canSwarmHealKephri(SwarmNpc swarm)
+	{
+		int wave = swarm.getWaveSpawned();
+		int npcIndex = swarm.getNpc().getIndex();
+
+		// First down
+		if (kephriDownCount == 1)
+		{
+			if (wave >= 1 && wave <= 18)
+			{
+				return true;
+			}
+
+			// special case: swarm 19
+			if (wave == 19 && kephriNpcIndex != -1 && npcIndex < kephriNpcIndex)
+			{
+				return true;
+			}
+		}
+
+		// Second down
+		if (kephriDownCount == 2)
+		{
+			if (wave >= 1 && wave <= 14)
+			{
+				return true;
+			}
+
+			// special case: swarm 15
+			if (wave == 15 && kephriNpcIndex != -1 && npcIndex < kephriNpcIndex)
+			{
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Subscribe
@@ -257,6 +299,11 @@ public class SwarmerOverlay extends Overlay implements PluginLifecycleComponent
 
 	private void draw(Graphics2D graphics, SwarmNpc swarmer, int offset)
 	{
+		if (config.swarmerOnlyLabelHealing() && !canSwarmHealKephri(swarmer))
+		{
+			return;
+		}
+
 		String text = String.valueOf(swarmer.getWaveSpawned());
 
 		Point canvasTextLocation = swarmer.getNpc().getCanvasTextLocation(graphics, text, 0);


### PR DESCRIPTION
This PR adds a toggleable option (default disabled) to only show the swarm number on swarms that will actually heal Kephri. This also takes into account NPC index rollover, which can rarely cause swarm 19 and 15 to heal kephri on the 1st and 2nd down, respectively.

<img width="247" height="265" alt="image" src="https://github.com/user-attachments/assets/6a696fd6-8c9f-46a3-994d-bb77d6bc154c" />

Video examples are below. Note that in examples showing pid loop/no pid loop, the NPC ID plugin is enabled so you can see the NPC index. That is not part of the change, just informational to confirm what's happening

Toggled ON, no pid loop:

https://github.com/user-attachments/assets/f02ec682-b598-412a-9516-cab0ab684d38

Toggled ON, pid loop:

https://github.com/user-attachments/assets/9807fc37-7f18-427b-8f5b-57dcd2ffec10

Toggled OFF:

https://github.com/user-attachments/assets/fbc461df-a8f4-49f4-9eac-108b9694fb4d


